### PR TITLE
refactor(managed-memory): use ValueTask for Init/Destroy delegates + scoped DI tests

### DIFF
--- a/src/Quark.Core.Abstractions/Hosting/IManagedActivationMemory.cs
+++ b/src/Quark.Core.Abstractions/Hosting/IManagedActivationMemory.cs
@@ -20,14 +20,14 @@ public interface IManagedActivationMemory<T> where T : class
     ///     Configures the async factory used to create the resource on first access.
     ///     Must be called before <see cref="GetAsync"/> is first invoked.
     /// </summary>
-    IManagedActivationMemory<T> Init(Func<Task<T>> factory);
+    IManagedActivationMemory<T> Init(Func<ValueTask<T>> factory);
 
     /// <summary>
     ///     Configures the async callback invoked to clean up the resource on grain deactivation.
     ///     Called after the grain's <c>OnDeactivateAsync</c> completes.
     ///     Optional: omit if the resource requires no explicit cleanup.
     /// </summary>
-    IManagedActivationMemory<T> Destroy(Func<T, Task> cleanup);
+    IManagedActivationMemory<T> Destroy(Func<T, ValueTask> cleanup);
 
     /// <summary>
     ///     Returns the resource value, initializing it on first access via the factory

--- a/src/Quark.Persistence.Abstractions/ManagedActivationMemoryAccessor.cs
+++ b/src/Quark.Persistence.Abstractions/ManagedActivationMemoryAccessor.cs
@@ -12,13 +12,13 @@ public sealed class ManagedActivationMemoryAccessor<T>(ManagedActivationMemoryHo
     : IManagedActivationMemory<T>
     where T : class
 {
-    public IManagedActivationMemory<T> Init(Func<Task<T>> factory)
+    public IManagedActivationMemory<T> Init(Func<ValueTask<T>> factory)
     {
         holder.Init(factory);
         return this;
     }
 
-    public IManagedActivationMemory<T> Destroy(Func<T, Task> cleanup)
+    public IManagedActivationMemory<T> Destroy(Func<T, ValueTask> cleanup)
     {
         holder.Destroy(cleanup);
         return this;

--- a/src/Quark.Persistence.Abstractions/ManagedActivationMemoryHolder.cs
+++ b/src/Quark.Persistence.Abstractions/ManagedActivationMemoryHolder.cs
@@ -12,16 +12,16 @@ public sealed class ManagedActivationMemoryHolder<T> : IManagedActivationMemory<
 {
     private T? _value;
     private bool _initialized;
-    private Func<Task<T>>? _factory;
-    private Func<T, Task>? _cleanup;
+    private Func<ValueTask<T>>? _factory;
+    private Func<T, ValueTask>? _cleanup;
 
-    public IManagedActivationMemory<T> Init(Func<Task<T>> factory)
+    public IManagedActivationMemory<T> Init(Func<ValueTask<T>> factory)
     {
         _factory = factory;
         return this;
     }
 
-    public IManagedActivationMemory<T> Destroy(Func<T, Task> cleanup)
+    public IManagedActivationMemory<T> Destroy(Func<T, ValueTask> cleanup)
     {
         _cleanup = cleanup;
         return this;

--- a/tests/Quark.Tests.Unit/Integration/ManagedMemoryGrainTests.cs
+++ b/tests/Quark.Tests.Unit/Integration/ManagedMemoryGrainTests.cs
@@ -46,9 +46,9 @@ public sealed class ManagedBufferBehavior : IGrainBehavior, IManagedBufferGrain,
             {
                 var buf = new ManagedBuffer();
                 buf.InitCount++;
-                return Task.FromResult(buf);
+                return ValueTask.FromResult(buf);
             })
-            .Destroy(b => { b.DestroyCount++; return Task.CompletedTask; });
+            .Destroy(b => { b.DestroyCount++; return ValueTask.CompletedTask; });
     }
 
     public async Task<long> GetInitCountAsync()

--- a/tests/Quark.Tests.Unit/Persistence/ManagedActivationMemoryTests.cs
+++ b/tests/Quark.Tests.Unit/Persistence/ManagedActivationMemoryTests.cs
@@ -1,4 +1,7 @@
+using Microsoft.Extensions.DependencyInjection;
+using Quark.Core.Abstractions.Hosting;
 using Quark.Persistence.Abstractions;
+using Quark.Runtime;
 using Xunit;
 
 namespace Quark.Tests.Unit.Persistence;
@@ -10,7 +13,7 @@ public sealed class ManagedActivationMemoryTests
     {
         int callCount = 0;
         var holder = new ManagedActivationMemoryHolder<MyResource>();
-        holder.Init(() => { callCount++; return Task.FromResult(new MyResource()); });
+        holder.Init(() => { callCount++; return ValueTask.FromResult(new MyResource()); });
 
         await holder.GetAsync();
 
@@ -22,7 +25,7 @@ public sealed class ManagedActivationMemoryTests
     {
         var resource = new MyResource();
         var holder = new ManagedActivationMemoryHolder<MyResource>();
-        holder.Init(() => Task.FromResult(resource));
+        holder.Init(() => ValueTask.FromResult(resource));
 
         MyResource r1 = await holder.GetAsync();
         MyResource r2 = await holder.GetAsync();
@@ -38,7 +41,7 @@ public sealed class ManagedActivationMemoryTests
     {
         int callCount = 0;
         var holder = new ManagedActivationMemoryHolder<MyResource>();
-        holder.Init(() => { callCount++; return Task.FromResult(new MyResource()); });
+        holder.Init(() => { callCount++; return ValueTask.FromResult(new MyResource()); });
 
         await holder.GetAsync();
         await holder.GetAsync();
@@ -59,7 +62,7 @@ public sealed class ManagedActivationMemoryTests
     public void IsInitialized_Returns_False_Before_GetAsync()
     {
         var holder = new ManagedActivationMemoryHolder<MyResource>();
-        holder.Init(() => Task.FromResult(new MyResource()));
+        holder.Init(() => ValueTask.FromResult(new MyResource()));
 
         Assert.False(holder.IsInitialized);
     }
@@ -68,7 +71,7 @@ public sealed class ManagedActivationMemoryTests
     public async Task IsInitialized_Returns_True_After_GetAsync()
     {
         var holder = new ManagedActivationMemoryHolder<MyResource>();
-        holder.Init(() => Task.FromResult(new MyResource()));
+        holder.Init(() => ValueTask.FromResult(new MyResource()));
 
         await holder.GetAsync();
 
@@ -80,8 +83,8 @@ public sealed class ManagedActivationMemoryTests
     {
         bool cleanupCalled = false;
         var holder = new ManagedActivationMemoryHolder<MyResource>();
-        holder.Init(() => Task.FromResult(new MyResource()))
-              .Destroy(_ => { cleanupCalled = true; return Task.CompletedTask; });
+        holder.Init(() => ValueTask.FromResult(new MyResource()))
+              .Destroy(_ => { cleanupCalled = true; return ValueTask.CompletedTask; });
 
         await holder.GetAsync();
         await holder.DisposeAsync();
@@ -95,8 +98,8 @@ public sealed class ManagedActivationMemoryTests
         var resource = new MyResource();
         MyResource? received = null;
         var holder = new ManagedActivationMemoryHolder<MyResource>();
-        holder.Init(() => Task.FromResult(resource))
-              .Destroy(r => { received = r; return Task.CompletedTask; });
+        holder.Init(() => ValueTask.FromResult(resource))
+              .Destroy(r => { received = r; return ValueTask.CompletedTask; });
 
         await holder.GetAsync();
         await holder.DisposeAsync();
@@ -109,8 +112,8 @@ public sealed class ManagedActivationMemoryTests
     {
         bool cleanupCalled = false;
         var holder = new ManagedActivationMemoryHolder<MyResource>();
-        holder.Init(() => Task.FromResult(new MyResource()))
-              .Destroy(_ => { cleanupCalled = true; return Task.CompletedTask; });
+        holder.Init(() => ValueTask.FromResult(new MyResource()))
+              .Destroy(_ => { cleanupCalled = true; return ValueTask.CompletedTask; });
 
         await holder.DisposeAsync();
 
@@ -121,7 +124,7 @@ public sealed class ManagedActivationMemoryTests
     public async Task DisposeAsync_Skips_Cleanup_When_Destroy_Not_Configured()
     {
         var holder = new ManagedActivationMemoryHolder<MyResource>();
-        holder.Init(() => Task.FromResult(new MyResource()));
+        holder.Init(() => ValueTask.FromResult(new MyResource()));
 
         await holder.GetAsync();
         // Should not throw even without Destroy configured.
@@ -132,7 +135,7 @@ public sealed class ManagedActivationMemoryTests
     public void Init_Returns_Same_Interface_For_Fluent_Chaining()
     {
         var holder = new ManagedActivationMemoryHolder<MyResource>();
-        var returned = holder.Init(() => Task.FromResult(new MyResource()));
+        var returned = holder.Init(() => ValueTask.FromResult(new MyResource()));
 
         Assert.Same(holder, returned);
     }
@@ -141,9 +144,46 @@ public sealed class ManagedActivationMemoryTests
     public void Destroy_Returns_Same_Interface_For_Fluent_Chaining()
     {
         var holder = new ManagedActivationMemoryHolder<MyResource>();
-        var returned = holder.Destroy(_ => Task.CompletedTask);
+        var returned = holder.Destroy(_ => ValueTask.CompletedTask);
 
         Assert.Same(holder, returned);
+    }
+
+    // -------------------------------------------------------------------------
+    // Scoped DI registration
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void AddManagedActivationMemory_Is_Registered_As_Scoped()
+    {
+        // IManagedActivationMemory<T> must be scoped so each per-call IServiceScope
+        // gets its own ManagedActivationMemoryAccessor (not a shared singleton).
+        var services = new ServiceCollection();
+        services.AddManagedActivationMemory<MyResource>();
+
+        ServiceDescriptor descriptor = services.Single(d =>
+            d.ServiceType == typeof(IManagedActivationMemory<MyResource>));
+
+        Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public async Task Multiple_Accessors_For_Same_Holder_Share_State()
+    {
+        // Each per-call scope gets a distinct ManagedActivationMemoryAccessor wrapping
+        // the same shell-owned ManagedActivationMemoryHolder. Verify that both accessors
+        // observe the same initialized value (resource is created exactly once).
+        var holder = new ManagedActivationMemoryHolder<MyResource>();
+        var accessor1 = new ManagedActivationMemoryAccessor<MyResource>(holder);
+        var accessor2 = new ManagedActivationMemoryAccessor<MyResource>(holder);
+
+        accessor1.Init(() => ValueTask.FromResult(new MyResource()));
+
+        MyResource r1 = await accessor1.GetAsync();
+        MyResource r2 = await accessor2.GetAsync();
+
+        Assert.Same(r1, r2);
+        Assert.True(accessor2.IsInitialized);
     }
 
     private sealed class MyResource { }

--- a/wiki/Persistence.md
+++ b/wiki/Persistence.md
@@ -52,7 +52,7 @@ public sealed class MetricsBehavior : IGrainBehavior, IMetricsGrain
     public MetricsBehavior(IManagedActivationMemory<RingBuffer> buffer)
     {
         _buffer = buffer
-            .Init(() => Task.FromResult(new RingBuffer(capacity: 1024)))
+            .Init(() => ValueTask.FromResult(new RingBuffer(capacity: 1024)))
             .Destroy(b => b.FlushAsync());
     }
 
@@ -64,8 +64,8 @@ public sealed class MetricsBehavior : IGrainBehavior, IMetricsGrain
 }
 ```
 
-- `Init(Func<Task<T>>)` — factory invoked on first `GetAsync()` call; result is cached for the activation lifetime.
-- `Destroy(Func<T, Task>)` — cleanup called **after** `OnDeactivateAsync` completes, so the grain can still read the resource during its own teardown.
+- `Init(Func<ValueTask<T>>)` — factory invoked on first `GetAsync()` call; result is cached for the activation lifetime.
+- `Destroy(Func<T, ValueTask>)` — cleanup called **after** `OnDeactivateAsync` completes, so the grain can still read the resource during its own teardown.
 - `IsInitialized` — `false` until the first `GetAsync()` succeeds; `Destroy` is a no-op if the resource was never initialized.
 
 Register in silo startup:


### PR DESCRIPTION
## Summary

- Convert `IManagedActivationMemory<T>.Init` and `Destroy` delegate signatures from `Task`/`Task<T>` to `ValueTask`/`ValueTask<T>` — avoids a heap allocation for the common case where the factory is already-completed (e.g. `ValueTask.FromResult(new MyResource())`)
- Update all call sites: `ManagedActivationMemoryHolder<T>`, `ManagedActivationMemoryAccessor<T>`, integration test behavior, wiki example
- Add two new unit tests:
  - `AddManagedActivationMemory_Is_Registered_As_Scoped` — asserts the DI registration lifetime is `Scoped`, matching how all other per-call services are registered
  - `Multiple_Accessors_For_Same_Holder_Share_State` — verifies that two different `ManagedActivationMemoryAccessor<T>` instances wrapping the same shell holder observe the same resource value (simulates distinct per-call scopes pointing to one activation's holder)

## Test plan

- [ ] `dotnet build Quark.slnx` — 0 errors
- [ ] `dotnet test tests/Quark.Tests.Unit/Quark.Tests.Unit.csproj` — 181 tests pass (includes 2 new)
- [ ] `dotnet test tests/Quark.Tests.CodeGenerator/Quark.Tests.CodeGenerator.csproj` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)