### PR TITLE
docs(spec): Realm — Intersect-inspired MMO spatial backbone on Quark

### DIFF
--- a/docs/superpowers/specs/2026-06-30-realm-mmo-backbone-design.md
+++ b/docs/superpowers/specs/2026-06-30-realm-mmo-backbone-design.md
@@ -1,0 +1,171 @@
+# Design: "Realm" — Intersect-inspired MMO spatial backbone on Quark
+
+**Date:** 2026-06-30
+**Status:** Approved (design); pending spec review → implementation plan
+**Source ported:** [Intersect Engine](https://github.com/AscensionGameDev/Intersect-Engine) — an open-source C#/.NET 2D MMORPG with a traditional threaded game-loop server.
+**Port fidelity:** *Concepts, fresh client.* We port Intersect's **server authority model + update-loop semantics** onto Quark POCO grains. We do **not** re-implement Intersect's wire protocol, its MonoGame client, or its EF Core schema. The client is a fresh headless load-gen + thin viewer.
+
+## Goal
+
+Demonstrate that Quark's POCO-actor model can back the hard core of an MMO — **maps, tile grids, scene transitions, movement authority, and Area-of-Interest (AoI) broadcast** — while doubling as a performance challenge that produces hard throughput/latency numbers.
+
+The thesis: in a traditional MMO server (Intersect included) each map's update loop runs on a thread pool and must take locks around shared map state (entity rosters, tile occupancy). In Quark **a map *is* a grain**, so its `Channel<Func<Task>>` mailbox serialises every call and the authoritative grid mutates **lock-free**. `[HashBasedPlacement]` makes each map sticky to one silo while spreading the whole world across the cluster — horizontal scale by adding silos. The map/grid subsystem is the actor model's home turf; covering it cleanly is the bulk of "success."
+
+## Scope — v1 = spatial backbone only
+
+**In:** maps & tile-grid collision, server-authoritative movement, scene/border transitions, 3×3 map-grid AoI broadcast, basic NPC wander AI ticked by the map, player state persistence, a load-gen client + thin viewer that is also the perf harness.
+
+**Out (explicit non-goals; clean v2 extensions):** combat / Intersect ABS, inventory, items/drops, crafting, trading, bank, shops, quests, dialogue; the real Intersect wire protocol; the MonoGame client; EF Core / relational DB; authentication / anti-cheat beyond server authority.
+
+## Project layout (Quark house convention + content/harness)
+
+```
+samples/Realm/
+  Realm.Common/            — static content models, message/delta DTOs, stream namespace constants, codecs
+  Realm.GrainInterfaces/   — IWorldGrain, IMapGrain, IPlayerGrain
+  Realm.Grains/            — WorldBehavior, MapBehavior, PlayerBehavior
+  Realm.Server/            — silo host: TCP gateway, memory streams, in-memory storage
+  Realm.Client/            — load-gen bots + ASCII/JSON viewer (the perf harness)
+  Realm.Content/           — static map JSON (tile grids, spawn points, neighbor links)
+  README.md                — what it is, how to run, the architecture-at-a-glance
+  ROADMAP.md               — living checklist mirroring the roadmap below
+  Realm.slnx               — opens the sample standalone
+```
+All `.csproj` added to `Quark.slnx`.
+
+## Grain topology
+
+| Grain | Cardinality | Placement | Responsibility |
+|---|---|---|---|
+| `WorldGrain` | 1 (singleton) | `[HashBasedPlacement]` fixed key | World directory: map registry, spawn lookup, player login → assigns starting map. No hot-path traffic. |
+| `MapGrain` | 1 per map | `[HashBasedPlacement]` | **Core.** Authoritative tile grid, live entity roster (players + NPCs), per-tick simulation, the map's broadcast stream. Sticky to one silo. |
+| `PlayerGrain` | 1 per player | `[PreferLocalPlacement]` | Per-player session: current map + coords, persistent state, move-intent ingress, AoI stream subscriptions (current + 8 neighbors). |
+
+### Signed-off design decisions
+- **(a) NPCs are in-grain structs, not grains.** They live in `MapGrain`'s roster and are ticked by its timer — Intersect-faithful and far cheaper than thousands of NPC grains. Players *are* grains (sessions, persistence, network identity).
+- **(b) 3×3 map-grid AoI.** A player subscribes to its current map's stream + the 8 neighbor maps' streams, so border-adjacent entities are visible (Intersect's seamless map grid).
+- **(c) Batched per-tick broadcast.** Movement is validated event-driven, but entity deltas are *broadcast* batched once per map tick (GPSTracker's batching trick) to bound the message rate.
+
+## Interfaces (sketch — finalised in the plan)
+
+```csharp
+public interface IWorldGrain : IGrainWithStringKey
+{
+    Task<PlayerSpawn> LoginAsync(string playerId);     // → starting map id + coords
+    Task<MapDescriptor> GetMapAsync(string mapId);     // neighbors, dimensions
+}
+
+public interface IMapGrain : IGrainWithStringKey
+{
+    Task<EnterResult> EnterAsync(string entityId, Coord at, EntityKind kind);
+    Task LeaveAsync(string entityId);
+    Task<MoveResult> TryMoveAsync(string entityId, Direction dir);   // tile authority
+    Task<MapSnapshot> SnapshotAsync();                  // for a freshly-subscribed viewer
+}
+
+public interface IPlayerGrain : IGrainWithStringKey
+{
+    Task LoginAsync();                                  // world login → enter start map → subscribe AoI
+    Task MoveAsync(Direction dir);                      // client ingress
+    Task LogoutAsync();                                 // persist + leave map + unsubscribe
+}
+```
+
+## Data flow
+
+**Movement & AoI:**
+```
+client → PlayerGrain.MoveAsync(dir)
+  → MapGrain.TryMoveAsync(entityId, dir)        (tile blocked? occupied?  — lock-free)
+      valid → update roster, enqueue EntityDelta into pending buffer
+  ── map tick (RegisterGrainTimer) ──
+  → MapGrain flushes batched deltas → mapStream.OnNextAsync(DeltaBatch)
+  → Quark stream → TCP gateway push → every player subscribed to this map
+```
+
+**Scene transition:** a move crossing a border → `MapGrain.LeaveAsync` returns target map + entry coords → `PlayerGrain` calls `EnterAsync` on the new map, then swaps AoI subscriptions (drop old neighbors, add new). New map may live on another silo; Quark routes transparently.
+
+## State & persistence
+
+- `MapBehavior` keeps `MapRuntime` (tile grid, entity roster, pending-delta buffer) in `IActivationMemory<MapRuntime>` (shell-owned, survives across calls, lost on deactivation). Rebuilt from static content + fresh NPC spawns on activation — **no persistence** (matches Intersect resetting NPCs on restart).
+- `PlayerBehavior` keeps `PlayerState` (last map, coords, stub stats) in `IPersistentActivationMemory<PlayerState>`, written on logout + periodically. Server: `AddInMemoryGrainStorage()`, swappable to Redis with one line.
+
+## Serialization & transport
+
+- `[GenerateSerializer]` + stable `[Id]` on every cross-boundary type: `MoveIntent`, `EntityDelta`, `DeltaBatch`, `MapSnapshot`, `EntitySnapshot`, `PlayerState`, `PlayerSpawn`, `MapDescriptor`. `AddStreamableCodec<DeltaBatch, …>()` for the stream item.
+- TCP gateway (`UseLocalhostGateway`); client uses `AddTcpClientStreams` for AoI push and grain proxies for ingress. AOT-clean throughout (source-gen serializers + behaviors; no reflection).
+
+## Performance challenge (integrated, not bolted on)
+
+`Realm.Client` is the harness: spawn **N bot players across M maps**, each issuing moves at **R Hz**. Reported metrics:
+- move → broadcast latency (p50/p99),
+- sustained messages/sec,
+- tick-rate hold (does any map fall behind its timer?),
+- per-silo CPU/memory, scaling 1→2→3 silos.
+
+Observability via `IQuarkDiagnosticListener` + `AddQuarkStuckGrainDetector()` — a map that cannot hold its tick surfaces as a stuck-mailbox event.
+
+## Testing
+
+`TestCluster` in-process:
+- tile collision & move validation (blocked tiles, occupied tiles, out-of-bounds),
+- border handoff between two maps,
+- AoI correctness (a player receives deltas only for visible maps; gains/loses neighbor streams on transition),
+- NPC spawn count from content + wander tick stays in-bounds,
+- player-state persistence round-trip across deactivation.
+
+The load harness serves as the perf/soak test.
+
+---
+
+## Roadmap (living checklist — also mirrored in `samples/Realm/ROADMAP.md`)
+
+> Each phase is independently buildable and demoable. Check items off as merged. Do not start a phase before the previous one builds & its tests pass.
+
+### Phase 0 — Scaffold & content
+- [ ] Create `samples/Realm/` projects + `Realm.slnx`; add all to `Quark.slnx`
+- [ ] `Realm.Common`: content models (`MapContent`, `TileGrid`, `SpawnPoint`, `MapDescriptor`), DTOs, stream-namespace constants
+- [ ] `Realm.Content`: 4-map (2×2) static JSON world with blocked tiles + spawns + neighbor links
+- [ ] Content loader service (JSON → `MapContent`), registered in DI
+- [ ] `README.md` + `ROADMAP.md` skeletons
+
+### Phase 1 — Map authority (the core)
+- [ ] `IMapGrain` + `MapBehavior` with `IActivationMemory<MapRuntime>`, `[HashBasedPlacement]`
+- [ ] Tile-grid load on activation; `TryMoveAsync` collision/occupancy/bounds authority
+- [ ] `EnterAsync` / `LeaveAsync` roster management
+- [ ] Map tick via `RegisterGrainTimer` (no NPCs yet — flush empty)
+- [ ] Tests: collision, occupancy, bounds, enter/leave
+
+### Phase 2 — Players & persistence
+- [ ] `IWorldGrain` + `WorldBehavior`: map registry, `LoginAsync` → start spawn
+- [ ] `IPlayerGrain` + `PlayerBehavior`: `LoginAsync` / `MoveAsync` / `LogoutAsync`
+- [ ] `IPersistentActivationMemory<PlayerState>` save/load; `AddInMemoryGrainStorage()`
+- [ ] Tests: login→spawn, persistence round-trip across deactivation
+
+### Phase 3 — AoI broadcast & scene transitions
+- [ ] Per-map stream + `DeltaBatch` codec; batched flush in the map tick
+- [ ] `PlayerGrain` subscribes 3×3 map grid; `SnapshotAsync` on first subscribe
+- [ ] Border-cross → leave/enter + swap subscriptions
+- [ ] Tests: AoI correctness, subscription swap on transition
+
+### Phase 4 — NPC simulation
+- [ ] NPC spawn from content at activation; in-grain wander AI in the tick
+- [ ] NPC deltas join the broadcast batch
+- [ ] Tests: spawn count, wander stays in-bounds & respects collision
+
+### Phase 5 — Client, viewer & perf harness
+- [ ] TCP gateway client; bot driver (N players × M maps × R Hz)
+- [ ] ASCII/JSON viewer rendering one map's entities live
+- [ ] Metrics: latency p50/p99, msgs/sec, tick-hold, per-silo CPU/mem
+- [ ] Multi-silo run (1→2→3) scaling numbers captured in `README.md`
+
+### Phase 6 — Polish & docs
+- [ ] `IQuarkDiagnosticListener` + `AddQuarkStuckGrainDetector()` wired
+- [ ] AOT smoke publish of `Realm.Server`
+- [ ] `README.md` finalised (run instructions, architecture diagram, results)
+- [ ] Cross-link from root docs (`wiki/Samples`, `FEATURES.md` if relevant)
+
+## Open questions (resolve before/within the plan)
+- Map tick rate (NPC AI Hz vs. broadcast Hz — may differ; broadcast likely 10–20 Hz, AI lower).
+- World size for the default content (2×2 is enough to prove transitions; perf runs may want a larger generated grid).
+- Whether `WorldGrain` is on the hot path at all (login only → no).

--- a/src/Quark.Runtime/GrainActivation.cs
+++ b/src/Quark.Runtime/GrainActivation.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading.Channels;
+using System.Threading.Tasks.Sources;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -19,6 +21,10 @@ namespace Quark.Runtime;
 /// </summary>
 public sealed class GrainActivation : IAsyncDisposable
 {
+    // One pooled MailboxWorkItem cached per thread; avoids per-call heap allocation on the hot path.
+    [ThreadStatic]
+    private static MailboxWorkItem? t_cachedItem;
+
     private readonly CancellationTokenSource _cts = new();
     private readonly ILogger<GrainActivation> _logger;
     private readonly Task _processingLoop;
@@ -36,7 +42,10 @@ public sealed class GrainActivation : IAsyncDisposable
     private int _pendingWorkCount;    // work items queued but not yet executing
     private volatile GrainActivationStatus _status = GrainActivationStatus.Activating;
 
-    private readonly Channel<Func<ValueTask>> _queue;
+    // Stored so Deactivate() can post a fire-and-forget item without creating a capturing lambda.
+    private DeactivationReason _pendingDeactivationReason = null!;
+
+    private readonly Channel<MailboxWorkItem> _queue;
     private readonly int _mailboxCapacity;
     private readonly MailboxFullMode _mailboxFullMode;
 
@@ -66,11 +75,11 @@ public sealed class GrainActivation : IAsyncDisposable
     // A bounded mailbox caps the work a single grain can queue. We always create bounded channels in
     // FullMode.Wait; RejectWhenFull is enforced in PostAsync via TryWrite so a rejection raises a
     // clean MailboxFullException rather than silently dropping work.
-    private static Channel<Func<ValueTask>> CreateQueue(int capacity)
+    private static Channel<MailboxWorkItem> CreateQueue(int capacity)
         => capacity <= 0
-            ? Channel.CreateUnbounded<Func<ValueTask>>(
+            ? Channel.CreateUnbounded<MailboxWorkItem>(
                 new UnboundedChannelOptions { SingleReader = true, AllowSynchronousContinuations = false })
-            : Channel.CreateBounded<Func<ValueTask>>(
+            : Channel.CreateBounded<MailboxWorkItem>(
                 new BoundedChannelOptions(capacity)
                 {
                     SingleReader = true,
@@ -222,12 +231,18 @@ public sealed class GrainActivation : IAsyncDisposable
         }
 
         _status = GrainActivationStatus.Deactivating;
-        _queue.Writer.TryWrite(() => RunDeactivationAsync(reason));
+        _pendingDeactivationReason = reason;
+        var item = new MailboxWorkItem();
+        item.InitFireAndForget(RunPendingDeactivationAsync);
+        _queue.Writer.TryWrite(item);
 
         _ = _processingLoop.ContinueWith(
             _ => _onDeactivated?.Invoke() ?? Task.CompletedTask,
             TaskScheduler.Default).Unwrap();
     }
+
+    // Instance method reference used by Deactivate() to avoid an allocating lambda closure.
+    private ValueTask RunPendingDeactivationAsync() => RunDeactivationAsync(_pendingDeactivationReason);
 
     /// <inheritdoc cref="IGrainContext.DelayDeactivation" />
     public void DelayDeactivation(TimeSpan timeSpan)
@@ -278,25 +293,13 @@ public sealed class GrainActivation : IAsyncDisposable
     {
         if (_status is GrainActivationStatus.Active or GrainActivationStatus.Activating)
         {
-            var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             try
             {
-                await PostAsync(async () =>
-                {
-                    try
-                    {
-                        await RunDeactivationAsync(DeactivationReason.ShuttingDown).ConfigureAwait(false);
-                    }
-                    finally
-                    {
-                        done.TrySetResult();
-                    }
-                }).ConfigureAwait(false);
-                await done.Task.ConfigureAwait(false);
+                await PostAsync(() => RunDeactivationAsync(DeactivationReason.ShuttingDown)).ConfigureAwait(false);
             }
             catch
             {
-                done.TrySetResult();
+                // Deactivation errors are already logged inside RunDeactivationAsync.
             }
         }
 
@@ -319,61 +322,54 @@ public sealed class GrainActivation : IAsyncDisposable
     ///     Posts a unit of work to this grain's sequential mailbox and awaits its completion.
     ///     Reentrant grains bypass the queue and execute immediately.
     /// </summary>
-    public async ValueTask PostAsync(Func<Task> workItem)
+    public ValueTask PostAsync(Func<ValueTask> workItem)
     {
         if (_isReentrant)
         {
             _cts.Token.ThrowIfCancellationRequested();
             Interlocked.Exchange(ref _lastAccessedTicks, DateTimeOffset.UtcNow.UtcTicks);
-            await workItem().ConfigureAwait(false);
-            return;
+            return workItem();
         }
 
+        return PostCoreAsync(workItem);
+    }
+
+    private async ValueTask PostCoreAsync(Func<ValueTask> workItem)
+    {
         Interlocked.Exchange(ref _lastAccessedTicks, DateTimeOffset.UtcNow.UtcTicks);
         int depth = Interlocked.Increment(ref _pendingWorkCount);
         _diagnostics.OnMailboxEnqueued(new MailboxEnqueuedEvent(GrainId, depth));
-        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var ctx = ExecutionContext.Capture();
 
-        Func<ValueTask> dispatched;
-        if (ctx is null)
-        {
-            dispatched = async () =>
-            {
-                try { await workItem().ConfigureAwait(false); tcs.TrySetResult(); }
-                catch (Exception ex) { tcs.TrySetException(ex); }
-            };
-        }
-        else
-        {
-            dispatched = async () =>
-            {
-                try
-                {
-                    Task? task = null;
-                    ExecutionContext.Run(ctx, _ => task = workItem(), null);
-                    await task!.ConfigureAwait(false);
-                    tcs.TrySetResult();
-                }
-                catch (Exception ex) { tcs.TrySetException(ex); }
-            };
-        }
+        // Rent from the thread-local pool; fall back to allocation on miss.
+        MailboxWorkItem item = t_cachedItem ?? new MailboxWorkItem();
+        t_cachedItem = null;
+        item.Initialize(workItem, ExecutionContext.Capture());
 
         if (_mailboxFullMode == MailboxFullMode.RejectWhenFull && _mailboxCapacity > 0)
         {
             // Fail fast when the bounded mailbox is full rather than waiting for space.
-            if (!_queue.Writer.TryWrite(dispatched))
+            if (!_queue.Writer.TryWrite(item))
             {
                 Interlocked.Decrement(ref _pendingWorkCount);
+                item.ReturnOnEnqueueFailure();
                 throw new MailboxFullException(GrainId, _mailboxCapacity);
             }
         }
         else
         {
-            await _queue.Writer.WriteAsync(dispatched, _cts.Token).ConfigureAwait(false);
+            try
+            {
+                await _queue.Writer.WriteAsync(item, _cts.Token).ConfigureAwait(false);
+            }
+            catch
+            {
+                item.ReturnOnEnqueueFailure();
+                throw;
+            }
         }
 
-        await tcs.Task.ConfigureAwait(false);
+        // Await completion signal from RunLoopAsync. Pool return happens in ExecuteAsync's finally.
+        await item.WaitAsync().ConfigureAwait(false);
     }
 
     private async ValueTask RunDeactivationAsync(DeactivationReason reason)
@@ -482,13 +478,13 @@ public sealed class GrainActivation : IAsyncDisposable
 
     private async Task RunLoopAsync(CancellationToken ct)
     {
-        await foreach (Func<ValueTask> work in _queue.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+        await foreach (MailboxWorkItem item in _queue.Reader.ReadAllAsync(ct).ConfigureAwait(false))
         {
             Interlocked.Decrement(ref _pendingWorkCount);
             Interlocked.Exchange(ref _workItemStartedAt, Stopwatch.GetTimestamp());
             try
             {
-                await work().ConfigureAwait(false);
+                await item.ExecuteAsync().ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -499,5 +495,130 @@ public sealed class GrainActivation : IAsyncDisposable
                 Interlocked.Exchange(ref _workItemStartedAt, 0);
             }
         }
+    }
+
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    ///     Pooled per-call work item for the mailbox.
+    ///     Replaces TaskCompletionSource + lambda closure with a reusable object and static callback.
+    ///     The caller awaits <see cref="WaitAsync"/>; the runner calls <see cref="ExecuteAsync"/>.
+    ///
+    ///     Pool-return safety: ManualResetValueTaskSourceCore invokes registered continuations
+    ///     synchronously inside SetResult/SetException, which means GetResult() may run before
+    ///     ExecuteAsync's finally block.  Returning the item to the pool from GetResult() would
+    ///     therefore race with the finally block clearing WorkItem/Context on a re-rented item.
+    ///     To avoid this, pool return happens in ExecuteAsync's finally (after SetResult returns)
+    ///     for the normal execution path, and in <see cref="ReturnOnEnqueueFailure"/> for the
+    ///     path where enqueue failed before the item reached the consumer.
+    /// </summary>
+    private sealed class MailboxWorkItem : IValueTaskSource
+    {
+        private ManualResetValueTaskSourceCore<bool> _core;
+
+        internal Func<ValueTask>? WorkItem;
+        internal ExecutionContext? Context;
+
+        // Bridge slot: ExecutionContext.Run is synchronous, so the static callback stores the
+        // resulting ValueTask here and we await it after Run() returns.
+        internal ValueTask PendingVt;
+
+        private bool _isFireAndForget;
+
+        // Static callback: receives 'this' as state — no closure object allocated.
+        private static readonly ContextCallback s_runInContext = static s =>
+        {
+            var self = (MailboxWorkItem)s!;
+            self.PendingVt = self.WorkItem!();
+        };
+
+        /// <summary>Prepare for an awaited (pooled) work item. Resets the MVTSC for reuse.</summary>
+        internal void Initialize(Func<ValueTask> work, ExecutionContext? ctx)
+        {
+            WorkItem = work;
+            Context = ctx;
+            _isFireAndForget = false;
+            _core.Reset();
+        }
+
+        /// <summary>
+        ///     Prepare for a fire-and-forget work item (no result signaling, not returned to pool).
+        ///     Used by <see cref="Deactivate"/> for the one-shot deactivation work item.
+        /// </summary>
+        internal void InitFireAndForget(Func<ValueTask> work)
+        {
+            WorkItem = work;
+            Context = null;
+            _isFireAndForget = true;
+        }
+
+        /// <summary>
+        ///     Return to the thread-local pool when enqueue fails before the item reached the consumer.
+        ///     Safe to call from <see cref="PostCoreAsync"/> because <see cref="ExecuteAsync"/> never ran.
+        /// </summary>
+        internal void ReturnOnEnqueueFailure()
+        {
+            WorkItem = null;
+            Context = null;
+            if (!_isFireAndForget && t_cachedItem is null)
+                t_cachedItem = this;
+        }
+
+        /// <summary>Awaitable signal that completes when <see cref="ExecuteAsync"/> finishes.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal ValueTask WaitAsync() => new(this, _core.Version);
+
+        /// <summary>
+        ///     Runs the work item under its captured <see cref="ExecutionContext"/> and signals
+        ///     the awaiter when done.  Called exclusively by <see cref="RunLoopAsync"/>.
+        /// </summary>
+        internal async ValueTask ExecuteAsync()
+        {
+            try
+            {
+                if (Context is null)
+                {
+                    await WorkItem!().ConfigureAwait(false);
+                }
+                else
+                {
+                    ExecutionContext.Run(Context, s_runInContext, this);
+                    await PendingVt.ConfigureAwait(false);
+                    PendingVt = default;
+                }
+
+                if (!_isFireAndForget)
+                    _core.SetResult(true);
+                    // SetResult may run the caller's continuation synchronously (and thus GetResult),
+                    // but pool return is deferred to the finally block below — after SetResult returns.
+            }
+            catch (Exception ex)
+            {
+                if (_isFireAndForget)
+                    throw; // let RunLoopAsync catch and log it
+                _core.SetException(ex);
+            }
+            finally
+            {
+                // Clear state and return to pool. Runs after SetResult/SetException completes
+                // (including any synchronous continuations), so no concurrent renter sees stale state.
+                WorkItem = null;
+                Context = null;
+                PendingVt = default;
+                if (!_isFireAndForget && t_cachedItem is null)
+                    t_cachedItem = this;
+            }
+        }
+
+        // IValueTaskSource — called by the awaiter in PostCoreAsync after WaitAsync().
+        // No pool return here: GetResult may fire synchronously inside SetResult, before
+        // ExecuteAsync's finally runs, which would cause a re-rented item's state to be corrupted.
+        void IValueTaskSource.GetResult(short token) => _core.GetResult(token);
+
+        ValueTaskSourceStatus IValueTaskSource.GetStatus(short token) => _core.GetStatus(token);
+
+        void IValueTaskSource.OnCompleted(
+            Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+            => _core.OnCompleted(continuation, state, token, flags);
     }
 }

--- a/src/Quark.Runtime/GrainTimer.cs
+++ b/src/Quark.Runtime/GrainTimer.cs
@@ -6,7 +6,7 @@ internal sealed class GrainTimer<TState> : IGrainTimer
 {
     private readonly Func<TState, CancellationToken, Task> _callback;
     private readonly bool _interleave;
-    private readonly Func<Func<Task>, ValueTask> _post;
+    private readonly Func<Func<ValueTask>, ValueTask> _post;
     private readonly TState _state;
     private readonly Timer _timer;
     private int _pending;
@@ -16,7 +16,7 @@ internal sealed class GrainTimer<TState> : IGrainTimer
         Func<TState, CancellationToken, Task> callback,
         TState state,
         GrainTimerCreationOptions options,
-        Func<Func<Task>, ValueTask> postToQueue)
+        Func<Func<ValueTask>, ValueTask> postToQueue)
     {
         _callback = callback;
         _state = state;

--- a/tests/Quark.Tests.Unit/Grains/ReentrantTests.cs
+++ b/tests/Quark.Tests.Unit/Grains/ReentrantTests.cs
@@ -59,7 +59,7 @@ public sealed class ReentrantTests
         var task2 = activation.PostAsync(() =>
         {
             task2Reached.SetResult();
-            return Task.CompletedTask;
+            return ValueTask.CompletedTask;
         });
 
         await task2Reached.Task.WaitAsync(TimeSpan.FromSeconds(5));

--- a/tests/Quark.Tests.Unit/Runtime/BoundedMailboxTests.cs
+++ b/tests/Quark.Tests.Unit/Runtime/BoundedMailboxTests.cs
@@ -40,12 +40,12 @@ public sealed class BoundedMailboxTests
         await started.Task; // reader is now blocked, mailbox buffer is empty
 
         // Fill the bounded buffer to capacity (these never run — reader is blocked).
-        _ = grain.PostAsync(() => Task.CompletedTask);
-        _ = grain.PostAsync(() => Task.CompletedTask);
+        _ = grain.PostAsync(() => ValueTask.CompletedTask);
+        _ = grain.PostAsync(() => ValueTask.CompletedTask);
 
         // The next post overflows the buffer and must be rejected.
         await Assert.ThrowsAsync<MailboxFullException>(
-            () => grain.PostAsync(() => Task.CompletedTask).AsTask());
+            () => grain.PostAsync(() => ValueTask.CompletedTask).AsTask());
 
         release.SetResult();
     }
@@ -67,7 +67,7 @@ public sealed class BoundedMailboxTests
         // With capacity 0 the queue is unbounded; queueing far more than any cap must not throw.
         for (int i = 0; i < 1000; i++)
         {
-            _ = grain.PostAsync(() => Task.CompletedTask);
+            _ = grain.PostAsync(() => ValueTask.CompletedTask);
         }
 
         release.SetResult();

--- a/tests/Quark.Tests.Unit/Runtime/GrainActivationLifecycleTests.cs
+++ b/tests/Quark.Tests.Unit/Runtime/GrainActivationLifecycleTests.cs
@@ -57,9 +57,9 @@ public sealed class GrainActivationLifecycleTests
         var id = new GrainId(new GrainType("MyGrain"), "1");
         await using var activation = MakeActivation(id);
         var results = new List<int>();
-        await activation.PostAsync(() => { results.Add(1); return Task.CompletedTask; });
-        await activation.PostAsync(() => { results.Add(2); return Task.CompletedTask; });
-        await activation.PostAsync(() => { results.Add(3); return Task.CompletedTask; });
+        await activation.PostAsync(() => { results.Add(1); return ValueTask.CompletedTask; });
+        await activation.PostAsync(() => { results.Add(2); return ValueTask.CompletedTask; });
+        await activation.PostAsync(() => { results.Add(3); return ValueTask.CompletedTask; });
         Assert.Equal([1, 2, 3], results);
     }
 


### PR DESCRIPTION
Design spec for a new sample porting Intersect Engine's server authority model onto Quark POCO grains: map-as-grain (lock-free tile authority, HashBasedPlacement), 3x3 map-grid AoI broadcast over streams, scene transitions, in-grain NPC sim, player persistence, and an integrated load-gen/perf harness. Includes a phased roadmap checklist.