### PR TITLE
Low-alloc dispatch: dual behavior model, opt-in arena scheduler, allocation-free park primitive

### DIFF
--- a/docs/superpowers/specs/2026-07-12-next-gen-scheduler-design.md
+++ b/docs/superpowers/specs/2026-07-12-next-gen-scheduler-design.md
@@ -1,0 +1,256 @@
+# Next-Generation Silo Scheduler — Design
+
+**Status:** Draft · **Date:** 2026-07-12 · **Scope:** Silo runtime only (no client/transport changes) · **Supersedes:** the `ActivationScheduler` / sharded-ready-queue / work-stealing line of specs (2026-07-03 → 2026-07-09). Clean-slate; existing implementation is not a constraint.
+
+## 1. Goals & non-goals
+
+**Goals**
+
+- **High throughput, low tail latency** for the silo's grain-call dispatch loop.
+- **Thread-safe by construction** — the per-actor single-threaded turn invariant holds with *zero per-grain locks*, purely through single-ownership of the schedulable unit.
+- **NUMA-aware** execution: dedicated pinned worker threads grouped into arenas with node-local memory pools; affinity is **opt-in** and degrades cleanly to a single arena on cloud VMs.
+- **Two-axis priority**: *actor priority* (which grain runs next, cross-actor) and *message priority* (which message within a grain runs next), FIFO within a lane, **non-preemptive** turns.
+- **Static + dynamic priority**: attribute defaults, runtime overrides.
+- **Cooperative cancellation** in two phases: *cancel-in-queue* (drop before dispatch) and *cancel-at-runtime* (cooperative token into the running turn).
+- **Work stealing** for intra-node load balancing, with cross-arena stealing as an escape valve.
+- **Bounded fairness** via a composite *worker budget* (message count + time quantum) and deficit round-robin across priority bands.
+
+**Non-goals**
+
+- Preemptive interruption of a running turn (rejected: breaks turn atomicity).
+- Cross-silo/placement load balancing (that's placement's job — this schedules within one silo).
+- Changing the engine model: schedulable unit stays the **activation**, behaviors stay per-call POCOs, mailbox stays MPSC-single-consumer.
+
+## 2. Core model & invariants
+
+The schedulable unit is the **`GrainActivation`**, *not* the message. This is the load-bearing decision:
+
+- An activation is **"ready"** when its mailbox holds undispatched work.
+- A ready activation is owned by **exactly one worker at a time** (a CAS'd `_scheduled` claim). While claimed, no other worker can touch it — this *is* the thread-safety guarantee. No lock is needed because ownership, not mutual exclusion, enforces single-threadedness.
+- Work stealing moves *activations* between workers. Because a stolen activation carries its exclusive claim, stealing is safe with no extra synchronization on grain state.
+- A worker, holding an activation, **drains** its mailbox (up to the worker budget) honoring message-priority lanes, then either yields (re-enqueue) or releases the claim.
+
+Invariants (must hold at all times):
+
+1. **I1 — Single turn:** for a non-reentrant activation, at most one turn executes at any instant, on one thread.
+2. **I2 — Single claim:** an activation appears in at most one worker run-queue / injection queue at a time.
+3. **I3 — Intra-lane FIFO:** messages in the same priority lane of the same activation execute in arrival order.
+4. **I4 — No lost wake:** every empty→non-empty mailbox transition results in the activation being scheduled and a worker eventually servicing it (no message stranded).
+5. **I5 — Progress:** the system makes forward progress even under reentrant call chains that exhaust the worker pool (stall watchdog + rescue capacity).
+
+## 3. Topology & arenas (NUMA)
+
+```
+SchedulerTopology  (discovered once at silo start)
+ ├─ Arena 0  (NUMA node 0)
+ │   ├─ Worker 0  (thread, pinned core 0)   local run-queues + steal
+ │   ├─ Worker 1  (thread, pinned core 1)
+ │   ├─ ArenaPool          node-local object pool (mailbox nodes, work items)
+ │   ├─ InjectionQueue     MPMC — external/rebalanced ready activations
+ │   └─ IdleStack          parked-worker registry + per-worker semaphores
+ ├─ Arena 1  (NUMA node 1)  …
+ └─ neighbor map: arena → ordered list of steal targets (nearest node first)
+```
+
+- **Discovery.** On Linux, parse `/sys/devices/system/node/nodeN/cpulist`; on Windows, `GetLogicalProcessorInformationEx`. Guarded by `RuntimeInformation.IsOSPlatform`. If discovery fails or affinity is off → **one arena** spanning all logical cores.
+- **Affinity (opt-in, default off).** `EnableAffinity` + `AffinityMode { CorePin, NodePin }`. Core-pin sets a single-CPU mask per worker; node-pin sets the node's CPU set. P/Invoke `sched_setaffinity` (Linux) / `SetThreadAffinityMask` (Windows). Off → workers float; arenas remain a logical grouping for pool/steal locality.
+- **Arena assignment for a grain.** `arena = stableHash(GrainId) % arenaCount`. A grain's activation lives on one arena for its lifetime, so its `StateHolder<T>` bags, mailbox nodes, and work items all allocate from that arena's node-local pool → state stays on the node the worker runs on. Cross-arena movement happens only under load balancing (§9) and is the exception, not the rule.
+- **ArenaPool.** Magazine-style per-arena free lists for `MailboxMessage` nodes and pooled work items. Cross-arena frees return to the freeing thread's local magazine (bounded drift, standard allocator trade-off). Eliminates steady-state allocation on the hot path.
+
+## 4. Worker & run-queues (stealing)
+
+Each worker is a **dedicated `Thread`** (never the ThreadPool) running a tight loop:
+
+```
+loop:
+  a = PopLocal()                       // own deque, LIFO (hot, cache-warm)
+      ?? StealIntraArena()             // siblings' deques, FIFO end
+      ?? DrainInjectionQueue()         // arena rebalance/external
+      ?? StealNeighborArena()          // nearest neighbor first (escape valve)
+  if a == null: Park()                 // register idle, re-check, wait on semaphore
+  else: DrainActivation(a)             // §5 + §8
+```
+
+- **Run-queue = Chase-Lev work-stealing deque**, one per *actor-priority band* (§6). Owner pushes/pops the bottom (LIFO → freshest activation, warmest cache). Thieves steal the top (FIFO → oldest, fairest to steal). Lock-free.
+- **Band scan.** Pop scans bands high→low with **deficit round-robin** weights so Low is not starved (e.g. weights 4:2:1). Steal scans victim bands high→low.
+- **Steal policy.** Steal a **small batch** (`StealBatch`, e.g. 1–4) to amortize the steal cost but avoid convoying. Intra-arena victims chosen by randomized start index (avoids all thieves hammering worker 0). Neighbor-arena stealing only after intra-arena comes up empty, and can be capped (`StealNeighborArenas`) or disabled.
+- **Parking.** Per-arena idle stack + per-worker `SemaphoreSlim(0,…)`. On empty-after-double-check, worker pushes itself idle and waits. An enqueue that makes an activation ready wakes one idle worker *in that arena* (pop from idle stack, release its semaphore); if the arena has no idle worker, it may wake a neighbor arena's worker (cross-arena escape) so a saturated arena can shed. Double-check-before-park closes the lost-wake race (I4).
+
+## 5. Mailbox & priority lanes
+
+Replaces the single `Channel<IMailboxWorkItem>` with a lane-structured MPSC mailbox owned by the activation:
+
+```
+ActorMailbox
+ ├─ lanes[L]        L MPSC queues, one per message-priority level (Urgent..Low)
+ ├─ depth           total undispatched count (empty↔non-empty detection)
+ ├─ scheduled       CAS claim: is this activation in a run-queue right now?
+ └─ laneDeficit[L]  DRR counters so Urgent can't starve Low within an actor
+```
+
+- **Lane = Vyukov intrusive MPSC queue** of pooled `MailboxMessage` nodes. Many producers (callers) enqueue lock-free; one consumer (the owning worker) dequeues. Nodes come from the arena pool.
+- **Enqueue (producer):**
+  1. `node = pool.Rent(); node.priority = p; node.token = ct; node.promise = tcs;`
+  2. `lanes[p].Enqueue(node); Interlocked.Increment(ref depth);`
+  3. If `TryMarkScheduled()` wins the CAS (0→1) → push the activation onto a worker run-queue at its **effective band** (§6) and wake. If it loses, the activation is already scheduled; the message will be seen by the in-flight/next drain (I4).
+- **Drain (owning worker):** for each budget step, pick the highest non-empty lane subject to DRR deficit, dequeue, run the turn.
+- **`MailboxMessage` (pooled):** `{ workItem, priority, CancellationToken, TaskCompletionSource promise, volatile bool cancelled }`.
+
+## 6. Priority model
+
+Two independent axes, unified by an **effective band** for cross-actor scheduling.
+
+| Axis | Granularity | Mechanism |
+|---|---|---|
+| **Actor priority** | across activations | which run-queue **band** the activation sits in → which grain a worker picks next |
+| **Message priority** | within an activation | which **lane** of the mailbox drains first → which message of that grain runs next |
+
+- **Bands** (actor): `High, Normal, Low` (3, keeps run-queue count small). **Lanes** (message): `Urgent, High, Normal, Low` (4).
+- **Effective band = `max(actorBand, highestPendingLane)`** computed at the moment the scheduling CAS is won. So an Urgent message to a Low-priority actor schedules that activation in the High run-queue band — urgency crosses the actor boundary. Intra-actor ordering is still governed by lanes.
+  - *Lazy re-prioritization contract:* if a higher-priority message arrives while the activation is **already** queued at a lower band, it is still drained first *within* that turn (lane order, correct semantics); the cross-actor band boost applies on the next scheduling cycle. Cheap, documented, no dequeue-from-middle of a lock-free deque.
+- **Static defaults (compile-time):**
+  - `[ActorPriority(Priority.High)]` on the behavior class → baked into the generated registration; sets the activation's `actorBand` at activation.
+  - `[MessagePriority(Priority.Urgent)]` on an interface method → baked into the generated proxy/transport dispatcher; sets the default lane for that call.
+- **Dynamic overrides (runtime):**
+  - `ctx.SetActorPriority(Priority.Low)` — mutates `actorBand`; applies from the next scheduling cycle (lazy, as above).
+  - `RequestContext.SetPriority(Priority.Urgent)` at the call site — carried in the invocation, overrides the method's default lane for that one message.
+- **Anti-starvation:** DRR at both levels (across bands in the worker, across lanes in the mailbox). Optional aging (a Low item's effective lane is promoted after it has been skipped N times) can be layered on if starvation shows up in practice — off by default.
+
+## 7. Cancellation
+
+One `CancellationToken` per call, observed in two phases — this covers both keywords with one mechanism.
+
+- **Cancel-in-queue** (before dispatch): the token's registration flips `node.cancelled = true`. The drain loop skips cancelled nodes cheaply (tombstone — no mid-queue removal) and completes `node.promise` with `OperationCanceledException`. A bounded skip cap prevents a cancel-flood from monopolizing a drain. This is the "yank m4 out of the normal lane" behavior.
+- **Cancel-at-runtime** (during the turn): the *same* token is threaded into `ICallContext.CancellationToken`, visible to the running behavior. Cancellation is **cooperative** — the thread is never aborted; the grain observes the token and unwinds, the turn's Task completes (cancelled), the worker moves on. Turn atomicity is preserved; grain authors opt in by checking the token.
+- **Source of cancellation:** the caller's token (flowed through the proxy/invoker), a silo-initiated control signal (e.g., shutdown, deactivation), or a per-call deadline (`Message-TTL` integration — expired messages self-cancel in-queue).
+
+## 8. Worker budget & fairness
+
+The **worker budget** is a composite quantum bounding how long one activation holds a worker before yielding:
+
+- **Message budget** — max messages drained per turn (`DrainBudget`, e.g. 16).
+- **Time quantum** — max wall-time per turn (`Quantum`, e.g. 200µs). Checked between messages (turns are non-preemptive, so this bounds *multi-message* drains, not a single slow message).
+- **Yield rule:** stop when `messages ≥ DrainBudget` **or** `elapsed ≥ Quantum`. If lanes still hold work → re-mark scheduled, re-enqueue to the worker's run-queue (fairness yield). Else release the claim, then double-check lanes for a late enqueue (I4) and re-schedule if needed.
+
+This is what keeps a hot grain from monopolizing a worker while other activations wait, and bounds the latency any one activation adds to the queue behind it.
+
+## 9. Load balancing & stealing
+
+Three tiers, cheapest first:
+
+1. **Intra-arena stealing** (primary). Idle worker steals a batch from a busy sibling. Keeps the activation on its home node → state/pool stay warm.
+2. **Cross-arena stealing** (escape valve). Only when intra-arena is dry. Nearest-neighbor node first. Bounded/disable-able. Moving an activation off its home node costs locality, so it's a last resort under genuine imbalance.
+3. **Injection-queue rebalance.** New/external ready activations and shed work land on an arena's MPMC injection queue; workers drain it after their local deque but before neighbor stealing. A saturated arena that can't wake a local worker wakes a neighbor (§4 parking), letting pressure bleed across nodes.
+
+Placement (`stableHash(GrainId) % arenaCount`) is the *default* balancer — it spreads grains across arenas up front so stealing is the exception. Under skew (a few hot grains), stealing + effective-band scheduling smooths it out without central coordination.
+
+## 10. Overload & backpressure
+
+- **Per-mailbox bound.** Lanes share a total `MailboxCapacity`. On full: `MailboxFullMode.Wait` (async backpressure to the caller's `PostAsync`) or `RejectWhenFull` (throw `MailboxFullException`). Preserved from today.
+- **Arena admission.** Soft cap on total ready activations per arena; `SchedulerOverloadMode { Wait, RejectWhenFull, Shed }`. `Shed` pushes to the injection queue / neighbor arena instead of rejecting.
+- **Metrics-driven.** Overload state is observable (§12) so operators can size budgets/capacity.
+
+## 11. Stall / deadlock safety & reentrancy
+
+- **Reentrancy.** `[Reentrant]` activations may interleave turns: the drain can dispatch a new message before the prior turn's Task completes (bounded by budget). Non-reentrant activations keep strict single-turn (I1) via the claim. The reentrancy mode is a per-activation property (as today).
+- **Reentrancy deadlock** (the failure the previous line of specs fought): a grain call chain that re-enters the scheduler while every worker is blocked awaiting a downstream call can starve. **As of the async-resume worker (§17 PA, implemented 2026-07-12) this is structurally gone for V2** — a worker never blocks *inside* a turn, so an awaited nested call always frees its worker to make progress. The mitigations below now cover only the residual pathological edge (e.g. an unbounded fan-out of simultaneously-suspended turns) rather than the common nested-call case:
+  - Dedicated threads + stealing already reduce the blast radius vs. a fixed ThreadPool.
+  - **Per-arena stall watchdog:** if an arena shows no completed drain for `StallThreshold` while its ready queue is non-empty, spin a **transient rescue thread** that drains until the backlog clears, then retires. Same idea as today's overflow workers, scoped per arena. Emits a diagnostic.
+  - Await-heavy grain code should prefer reentrancy or `[AlwaysInterleave]` for call-into-self patterns — documented guidance, enforced by the existing reentrancy analyzer.
+
+## 12. Public API & DI seam
+
+Keep `IActivationScheduler` as the seam; widen it:
+
+```csharp
+public interface IActivationScheduler : IAsyncDisposable
+{
+    ValueTask ScheduleAsync(GrainActivation activation, CancellationToken ct = default);
+    void SetActorPriority(GrainActivation activation, Priority band);   // lazy, next cycle
+    SchedulerSnapshot Snapshot();                                       // arenas, depths, steals
+}
+```
+
+- `GrainActivation` swaps its `Channel<IMailboxWorkItem>` for `ActorMailbox`; `PostAsync` gains `(Priority, CancellationToken)`.
+- Message priority + cancellation flow from the proxy → `LocalGrainCallInvoker` / `TcpGatewayCallInvoker` → `PostAsync`.
+- `ICallContext` exposes `CancellationToken` and `SetActorPriority(...)`.
+- Registration: `services.AddQuarkRuntime()` wires the new scheduler; `BehaviorRegistrationGenerator` emits `[ActorPriority]`/`[MessagePriority]` metadata into the generated registration (no runtime reflection).
+
+## 13. Config surface (`SiloRuntimeOptions`)
+
+| Option | Default | Meaning |
+|---|---|---|
+| `ArenaCount` | auto (NUMA nodes) | logical arenas; 1 when affinity off / discovery fails |
+| `WorkersPerArena` | cores-in-node | dedicated threads per arena |
+| `EnableAffinity` | `false` | opt-in thread pinning |
+| `AffinityMode` | `CorePin` | `CorePin` \| `NodePin` |
+| `DrainBudget` | 16 | max messages per turn |
+| `Quantum` | 200µs | max time per turn |
+| `StealBatch` | 2 | activations stolen per steal |
+| `StealNeighborArenas` | 1 | 0 disables cross-arena steal |
+| `ActorPriorityBands` | 3 | High/Normal/Low run-queues |
+| `MessagePriorityLanes` | 4 | Urgent/High/Normal/Low |
+| `BandWeights` | 4:2:1 | DRR anti-starvation |
+| `MailboxCapacity` | 0 (unbounded) | per-activation lane total |
+| `MailboxFullMode` | `Wait` | `Wait` \| `RejectWhenFull` |
+| `OverloadMode` | `Wait` | `Wait` \| `RejectWhenFull` \| `Shed` |
+| `StallThreshold` | 5s | rescue-thread trigger |
+
+## 14. Diagnostics
+
+Extend `IQuarkDiagnosticListener` (all no-op defaults) with `in`-ref-struct events:
+
+- Arena/worker: `OnArenaConfigured`, `OnWorkerParked/Unparked`, `OnAffinityApplied`.
+- Steal/balance: `OnStealAttempt/Succeeded`, `OnCrossArenaSteal`, `OnInjectionRebalance`.
+- Mailbox/priority: `OnLaneDepthChanged`, `OnEffectiveBandBoosted`, `OnCancelInQueue`, `OnCancelAtRuntime`.
+- Fairness: `OnDrainYielded` (budget/quantum), `OnBandStarvationAging`.
+- Safety: `OnStallDetected`, `OnRescueWorkerSpawned/Retired`, `OnShutdownStalled`.
+
+Plus `QuarkInstruments` counters/histograms: per-arena ready depth, steal rate, park rate, drain duration, lane depths, cancel counts, effective-band boosts.
+
+## 15. AOT / trim
+
+- Lock-free structures use only `Interlocked`/`Volatile` → AOT-clean.
+- Affinity P/Invoke guarded by `RuntimeInformation.IsOSPlatform`; no dynamic code, no `DynamicMethod`.
+- Priority metadata is source-generated (no runtime reflection); `[ActorPriority]`/`[MessagePriority]` read by the generator.
+- Every new type stays in a `IsTrimmable=true` package; no `ISerializable`, no assembly scanning.
+
+## 16. Concrete data structures
+
+| Concern | Structure | Why |
+|---|---|---|
+| Worker run-queue | **Chase-Lev deque** per band | lock-free single-owner push/pop + steal |
+| Mailbox lane | **Vyukov intrusive MPSC** | O(1) lock-free multi-producer enqueue, single-consumer |
+| Arena injection | **MPMC bounded ring** (e.g. `BoundedMpmcQueue`) | many producers, many draining workers |
+| Idle registry | lock-free **Treiber stack** of worker ids + per-worker `SemaphoreSlim` | O(1) wake, no lost wake with double-check |
+| Object pooling | per-arena **magazine free lists** | node-local reuse, no hot-path alloc |
+| Priority pick | **deficit round-robin** counters | starvation-free weighted band/lane selection |
+
+## 17. Phased implementation plan
+
+1. **P1 — Skeleton & seam. ✅ implemented (2026-07-12).** New `ArenaScheduler` + `WorkStealingDeque` behind `IActivationScheduler`; single arena, no affinity, single lane/band. Selected via `SiloRuntimeOptions.SchedulerKind = ArenaV2` (default stays `Legacy`); `--v2` flag on the PingPong benchmark. Dedicated worker threads, per-worker CLR-style work-stealing deques, per-worker hashed injection shards, Treiber idle-stack parking with the proven push-then-double-check lost-wake ordering, and a **blocking drain** (allocation-free / no-ThreadPool-hop for synchronously-completing turns). Invariants I1 (no turn overlap) and I4 (no lost work) proven by `ArenaSchedulerConcurrencyStressTests` (64 activations/2 workers overlap + no-loss; 300× single-worker lost-wake and idle-park cycles).
+   - **Measured (32-core box, PingPong):** V2 reaches ~95% of the legacy scheduler when worker count is not oversubscribed by the in-process CPU-bound driver (pairs=32, workers=16: 365k vs 386k calls/s). At default workers=ProcessorCount it is ~84% (325k vs 386k) because 32 dedicated worker threads contend with the 32 CPU-bound driver threads for 32 cores — an in-process-benchmark artifact (a real silo's load arrives over the network, not from co-located CPU-spinning threads), not a dispatch-loop cost. The ~13% residual at backlog (pairs=256) is the same dedicated-thread-vs-ThreadPool oversubscription. Closing it fully needs the cooperative async-resume `SynchronizationContext` (frees the worker thread across awaits instead of blocking) — deferred as noted below.
+2. **P2 — Stealing & arenas. ◑ mechanism validated (2026-07-12); locality benefit blocked on P5.** Work-stealing deques, per-worker hashed injection shards, and from-worker local-deque routing are implemented and proven correct by `ArenaSchedulerStealingTests`: a single source drain fires 2000 fire-and-forget posts onto one worker's local deque; all 2000 complete exactly once, all take the from-worker route (`local==2000`, `external==1`), `steals>0`, and work spreads across multiple worker threads. Multi-arena / affinity still pending (P5).
+   - **AstroSim finding (the requested validation target).** AstroSim **cannot** validate stealing/locality: its `ChunkGrain` is `[Reentrant]`, so every call — the driver's `TickAsync` *and* all ≤26 nested `neighbor.GetAggregateAsync()` calls per tick — runs inline via `ReentrantSchedulingMode.Immediate` and never enters `ScheduleAsync`. Instrumentation confirms it directly: over a full run the arena scheduler recorded `external=0 local=0 steals=0` — the workers stay parked the entire time. Measured throughput (V2 ~99k vs legacy ~58–89k msg/s at grid=8) is dominated by JIT/GC/ThreadPool-contention noise (a 50%+ swing between identical legacy runs), **not** scheduling; any V2 edge is incidental (its dedicated workers park and cede the ThreadPool to the driver), not a scheduling win. Net: a reentrant-heavy workload is the wrong shape to exercise or benefit from the scheduler at all.
+   - **Design consequence — from-worker locality needs cooperative async resume.** Under a **blocking** drain, a non-reentrant grain that *awaits* a nested call blocks its worker; local-deque placement of the callee then *guarantees* a cross-core steal (the opposite of locality), and nesting deeper than the worker count deadlocks without rescue. From-worker locality therefore pays off only for fire-and-forget fan-out (validated above) or once an awaiting worker can run its own local work instead of blocking. This motivated bringing the async-resume worker forward — see **PA** below.
+
+**PA — Async resume (spill-to-ThreadPool on await). ✅ implemented (2026-07-12), brought forward from P5.** Instead of a per-worker `SynchronizationContext` event loop (which the runtime's pervasive `ConfigureAwait(false)` would defeat), the drain is split: a turn that completes **synchronously** finishes inline on the dedicated worker (no async frame, no ThreadPool hop — the CPU-bound fast path), and the instant a turn **awaits**, the drain's remainder runs as a ThreadPool continuation while the worker returns to its loop, free to run the very nested call the suspended turn is waiting on. The `_running`/`_scheduled` claims span the whole async drain, so single-threaded-per-activation still holds across the await. This structurally removes both the blocking-drain latency and the bounded-worker reentrancy deadlock (issue #167). Validated by `ArenaSchedulerAsyncResumeTests`: a **depth-8 non-reentrant call chain completes on a single worker** (blocking would deadlock at the first nested await) and on 2 workers (blocking would deadlock at depth 2). PingPong sync-path throughput is unregressed (V2 at 16 workers ≈ 395–456k calls/s, ahead of legacy's ≈ 346–394k on the same box).
+
+   - **In-flight bound (backpressure). ✅ implemented (2026-07-12).** Each worker holds at most `SchedulerMaxInFlightDrainsPerWorker` suspended (spilled) drains before it stops taking new work and parks until one of its own completes, bounding memory and open per-call scopes under a flood of slow-awaiting turns. The counter is touched only on the spill path, so the synchronous fast path pays a single `Volatile.Read` (always 0 when nothing spills) — PingPong is unregressed. The gate uses a Dekker-fenced `_capWaiting` flag with a single-winner CAS release, so no wake is lost and permit inflation is bounded. **The cap is a safety ceiling, not a throttle:** it defaults to 256/worker and *must* exceed the deepest legitimate non-reentrant nesting, because async-resume deadlock-freedom relies on a worker being able to take on the nested call it awaits — a cap below the nesting depth would reintroduce the bounded-worker deadlock. Validated by `ArenaSchedulerInFlightBoundTests`: with cap 4 and 2 workers, 40 simultaneously-suspending turns peak at exactly 8 concurrent suspensions (never exceeded) and all 40 still complete once released. Residual: a stall/rescue watchdog for the pathological all-workers-capped-and-stalled edge remains for P6.
+3. **P3 — Priority.** Lanes + bands, effective-band boost, DRR anti-starvation, static attributes via generator, dynamic setters. Semantics tests for I3 + priority ordering.
+   - **P3a — message-priority lanes. ✅ implemented (2026-07-12).** `MessagePriority { Low, Normal, High, Urgent }` (Quark.Core.Abstractions.Scheduling). `GrainActivation`'s single mailbox `Channel` became a 4-lane array (one `Channel` per priority, reusing the existing bounded/unbounded/Reject machinery — a bounded mailbox now bounds each lane independently); the drain reads the highest-priority non-empty lane first, FIFO within a lane. Because the lanes live in the shared mailbox, **both schedulers get message priority for free**. Exposed via a new `PostAsync(work, MessagePriority)` overload (the arity-1 overload is preserved for the timer's method-group use; existing callers post `Normal`). Validated by `MessagePriorityLaneTests` (drain order `urgent → high → normal-1 → normal-2 → low` with FIFO within the Normal lane). No hot-path regression: full unit suite 546/546 green, PingPong unchanged (the high→low lane scan on all-Normal traffic is lost in the noise — empty `Channel.TryRead` is cheap). *Strict* priority for now; DRR anti-starvation is a documented refinement (Low waits behind sustained High).
+   - **P3 remaining slices (not yet done):** actor-priority **bands** in the arena run-queues (per-worker × per-band deques/inject) + **effective band = max(actorBand, highest-pending-lane)**; `[ActorPriority]`/`[MessagePriority]` attributes + generator emission and `RequestContext.SetPriority()` / `ctx.SetActorPriority()` **call-site plumbing** (so far priority is set only via the `PostAsync` overload); and **cancel-in-queue** (needs the P4 cancellation token). `ActorPriority { Low, Normal, High }` is already defined, ready for the bands work.
+4. **P4 — Cancellation.** In-queue tombstone + at-runtime cooperative token, wired through invoker + `ICallContext`; integrate Message-TTL deadlines.
+5. **P5 — NUMA.** Topology discovery, opt-in affinity P/Invoke, node-local arena pools, cross-arena steal + rebalance. Validate on a real multi-socket box; confirm graceful single-arena fallback on cloud VMs.
+6. **P6 — Overload & safety.** Backpressure modes, arena admission/shed, stall watchdog + rescue threads, full diagnostics surface.
+
+Each phase is independently shippable behind the seam and benchmarked before the next.
+
+## 18. Open questions / risks
+
+- **Band re-prioritization latency** — lazy (next-cycle) application is cheap; if a use case needs *immediate* cross-actor re-banding, we'd need dequeue-from-middle (expensive) or a redirect marker. Defer until proven necessary.
+- **Cross-arena pool drift** — magazine free lists can drift objects off their home node under sustained cross-arena traffic. Bounded, but worth measuring; cap magazine size.
+- **Affinity vs. the .NET ThreadPool** — dedicated pinned threads coexist with the pool used elsewhere in the runtime (I/O, timers). On small boxes over-subscription is possible; `WorkersPerArena` and affinity are opt-in to manage this.
+- **Reentrancy deadlock residual** — rescue threads are a safety net, not a cure; the real fix stays "don't block a turn on a synchronous call into the same activation," enforced by the reentrancy analyzer.
+- **Quantum granularity** — 200µs default is a guess; must be tuned against real grain-turn cost distributions from the benchmarks.
+```

--- a/docs/superpowers/specs/2026-07-13-low-alloc-dispatch-design.md
+++ b/docs/superpowers/specs/2026-07-13-low-alloc-dispatch-design.md
@@ -1,0 +1,342 @@
+# Low-allocation dispatch: activation-scoped behaviors + handle mailbox
+
+**Date:** 2026-07-13
+**Status:** design — approved direction, not yet implemented
+**Motivates:** the two dominant per-call allocation buckets measured in
+`2026-07-13-scheduler-v2-pingpong-cost-profile.md` §4a.
+
+## Motivation
+
+Measured allocation on the real dispatch path (`DispatchPipelineBenchmarks`, `[MemoryDiagnoser]`):
+**2039 B per grain call**, splitting into two near-equal buckets plus a tail:
+
+| bucket | B/call | share | attacked by |
+|---|---:|---:|---|
+| DI scope + per-call resolution | 792 | 38.8% | **Part A** — activation-scoped behaviors |
+| Mailbox async (channel + wake + completion signal) | 742 | 36.4% | **Part B** — handle mailbox |
+| Outer invoke machinery | ~505 | 24.8% | partial (both) |
+
+At 560k calls/s (server GC) that is ~1.14 GB/s of garbage — the direct driver of the
+38.8%-of-CPU GC-poll cost. The two parts are **orthogonal** and ship independently.
+
+Guiding constraint (from the maintainer): **do not break the existing model; keep the
+developer focused on writing the grain.** Hence a *dual* behavior model, not a replacement.
+
+---
+
+## Part A — Dual behavior model (kills the 792 B for opted-in grains)
+
+### The two models, side by side
+
+| | `IGrainBehavior` (existing, default) | `IActivationBehavior` (new, opt-in) |
+|---|---|---|
+| Instance lifetime | **per call** — constructed fresh, discarded | **per activation** — constructed once, reused, disposed on deactivation |
+| DI scope | fresh `IServiceScope` per call | **one** activation scope for the whole activation |
+| Mutable instance fields | forbidden (QRK0020/0021) — state goes in `IActivationMemory<T>` | **allowed** — fields *are* the activation state |
+| Call-context | bound into the per-call scope | **ambient** via `IGrainContext.CallContext` (set per turn) |
+| Per-call alloc | 792 B (scope + resolve + construct) | **~0** steady-state |
+| Best for | the common case; stateless handlers; maximum isolation | hot-path grains; naturally stateful actors; Orleans-style migration |
+
+Both remain POCOs with constructor injection. Choosing a model is a one-word change to the
+interface list — nothing else in the grain changes.
+
+```csharp
+// Default, unchanged — per call, stateless, analyzer-enforced:
+public sealed class CartBehavior(IActivationMemory<CartState> state) : ICartGrain { ... }
+
+// Opt-in — per activation, fields hold state, cheap dispatch:
+public sealed class CounterBehavior : ICounterGrain, IActivationBehavior
+{
+    private long _count;                     // legit: lives for the activation
+    public Task<long> IncrementAsync() => Task.FromResult(++_count);
+}
+```
+
+### Runtime shape
+
+- **Activation scope.** `GrainActivation` gains an optional `IServiceScope` created lazily at
+  first activation for `IActivationBehavior` grain types, disposed in the shell's deactivation
+  path (the same place `IManagedActivationMemory<T>.Destroy` already runs). Per-call grains keep
+  the existing per-call scope untouched.
+- **One construction.** For an `IActivationBehavior`, the generator's typed factory runs **once**
+  from the activation scope; the instance is cached on the shell. Per call: set ambient
+  call-context → invoke the cached instance. No scope, no construct, no locked `ResolveService`.
+- **Ambient call-context.** `ICallContext` (caller id, idempotency key, cancellation) is no longer
+  a resolvable per-call service for this model — it would freeze at activation time. It is set on
+  the shell at the start of each turn and read via `IGrainContext.CallContext`.
+  - Non-reentrant: turns are serial → a single field on the shell is safe.
+  - `[Reentrant]`: concurrent turns → carry the context on the work item / `AsyncLocal`, not a
+    shared field.
+
+### Analyzer changes (`BehaviorStateAnalyzer`)
+
+- **QRK0020 / QRK0021** (mutable instance field / writable auto-property): **suppressed** for types
+  implementing `IActivationBehavior` — instance state is the point of this model.
+- **QRK0022** (mutable static): **still fires** — statics are shared across *all* activations and
+  remain wrong in both models.
+- **New QRK0023 (Warning), optional:** an `IActivationBehavior` that is also `[Reentrant]` and holds
+  mutable non-readonly fields → warn about unsynchronized concurrent access across interleaved turns.
+
+### Generator + DI
+
+- `BehaviorRegistrationGenerator` already emits a typed factory per behavior. It additionally emits a
+  **lifetime flag** (per-call vs per-activation) based on whether the class implements
+  `IActivationBehavior`, so the runtime selects the dispatch path with no reflection.
+- `AddGrainBehavior<,>()` records the flag; hand-wired registrations detect the interface at
+  registration time.
+
+### What Part A reclaims
+
+The full **792 B/call** for opted-in grains, **plus** removes the locked DI `ResolveService`
+contention (cost-profile §2b) for those grains. Per-call grains are unchanged.
+
+---
+
+## Part B — Handle mailbox (kills the 742 B)
+
+Replaces the per-activation `Channel<IMailboxWorkItem>[]` lanes (P3a) with a pooled, value-type
+handle design. `MailboxRoundTripReentrant` = 0 B proves the entire 742 B is this machinery, not the
+work — so the ceiling here is near-zero steady-state allocation.
+
+### Structures
+
+```csharp
+readonly struct MessageHandle {          // 16 B — lives in the ring slot, no per-message heap node
+    public readonly int  DescriptorId;   // index into the descriptor pool
+    public readonly int  Sequence;       // ABA / validity guard
+    public readonly byte Priority;       // lane
+}
+
+sealed class MessageDescriptor {         // pooled; Reset() on return
+    public IInvokablePayload Payload;        // the invokable
+    public PooledValueTaskSource Completion; // reusable IValueTaskSource — replaces the per-call TCS
+    public CancellationToken Ct;
+    public CallContext Context;
+}
+```
+
+### Design decisions specific to Quark
+
+- **Single-consumer.** A non-reentrant activation drains serially → exactly one consumer, many
+  producers = a bounded **MPSC** ring (Vyukov-style, per-slot sequence numbers). Cheaper and
+  allocation-free vs `System.Threading.Channels`, which is general-purpose and allocates nodes.
+- **Priority lanes stay as 4 rings**, not one — highest-non-empty-first drain stays trivial and
+  FIFO-within-lane (preserves P3a semantics). One ring can't reorder by priority.
+- **Backpressure = ring capacity.** The bounded ring *is* the in-flight bound; this subsumes the
+  earlier per-worker in-flight cap for the mailbox side.
+- **Completion via `PooledValueTaskSource`** (`ManualResetValueTaskSourceCore`-based), rented per
+  call, returned when the awaiter completes — removes the ~312 B `TaskCompletionSource`.
+- **Async-resume preserved.** The descriptor / signal returns to the pool at *continuation*, not at
+  drain, so a suspended turn keeps its descriptor until it truly completes.
+- **Payload pooling is the hard part.** The invokable is already a `struct`; boxing it into
+  `IInvokablePayload` per call is an allocation. True zero requires **per-invokable-type pooled
+  slabs**, which must be **generator-emitted** (AOT-safe, no reflection) — the generator already
+  enumerates every invokable type. This is the one slice with real correctness risk and is scoped
+  last.
+
+### What Part B reclaims
+
+Up to the full **742 B/call** for every non-reentrant grain (both behavior models benefit), with the
+pooled-signal slice (~312 B) landing first and the payload-slab slice (~430 B) last.
+
+---
+
+## AOT / trim
+
+- No reflection on any hot path: factories, lifetime flags, and payload slabs are all
+  generator-emitted. `ActivatorUtilities.CreateInstance` remains only the hand-wired fallback.
+- Pooled generics are closed at compile time per invokable/behavior type.
+- Only `Interlocked`/`Volatile` in the ring; no `DynamicMethod`, no `ISerializable`.
+
+## Phased plan (build order)
+
+1. **Server GC default/recommendation** — free +72%, independent, ship immediately (config/doc).
+2. **Part A** — dual behavior model. Bigger win (792 B + a lock), lower risk (no lock-free code, no
+   pooling). Slices: (a) `IActivationBehavior` + activation scope + one-construction path ✅;
+   (b) ambient call-context (partial — idempotency key refreshed per turn in `BindActivationBehavior`);
+   (c) analyzer QRK0020/21 suppression + QRK0022 kept + QRK0023 ✅;
+   (d) generator lifetime flag (currently a one-time `IsAssignableFrom` check per activation);
+   (e) benchmarks + trace re-run to confirm the DI bucket is gone ✅.
+
+   **Slice (a) — DONE (2026-07-13).** `IActivationBehavior` marker + a single activation-lifetime
+   `IServiceScope` + one cached behavior instance in `GrainActivation` (constructed once via
+   `EnsureActivationBehavior`, reused per call via `BindActivationBehavior`, disposed on deactivation);
+   `LocalGrainCallInvoker` fast-path branch; reentrant + `IActivationBehavior` throws `NotSupportedException`.
+   Measured on `DispatchPipelineBenchmarks`: **2039 B/call → 1253 B/call (−786 B, −38.5%)**, mean latency
+   **14.2 µs → 6.8 µs**. The −786 B matches the predicted 792 B DI bucket; the residual 1253 B is the
+   mailbox-async + outer-invoke buckets that **Part B** targets. Covered by
+   `ActivationScopedBehaviorTests` (instance reuse, field persistence, scope disposal + `OnDeactivate`
+   on the same instance, fresh-activation reset, reentrant-throws).
+
+   **Slice (c) — DONE (2026-07-13).** `BehaviorStateAnalyzer` now detects `IActivationBehavior` in the
+   type's interface set: QRK0020 (mutable instance field) and QRK0021 (writable auto-property) are
+   suppressed for it (per-activation fields are legitimate state), while QRK0022 (mutable static) still
+   fires for both models. New **QRK0023** (Warning) flags `[Reentrant]` + `IActivationBehavior` at build
+   time, surfacing the runtime `NotSupportedException` earlier. Registered in
+   `AnalyzerReleases.Unshipped.md`; covered by 7 new `BehaviorStateAnalyzerTests` (23 total green).
+   Still open: generator lifetime flag (d), reentrant support.
+3. **Part B** — handle mailbox. Slices: (a) `PooledValueTaskSource` completion (~312 B) behind the
+   existing mailbox API; (b) MPSC ring + `MessageHandle`/`MessageDescriptor` replacing the lanes,
+   preserving priority + async-resume + backpressure; (c) generator-emitted payload slabs (~430 B).
+   Re-run trace + `DispatchPipelineBenchmarks` after each slice.
+
+   **Slice (a) — DONE (2026-07-13), re-scoped.** The premise "swap the per-call `TaskCompletionSource`
+   for a pooled `IValueTaskSource`" turned out to be a **no-op**: the mailbox already pools its
+   completion signal via `ManualResetValueTaskSourceCore<bool>` inside the thread-pooled
+   `MailboxWorkItem` classes (`GrainActivation.cs` ~line 1120). The `TaskCompletionSource` at line 44
+   is the per-activation *deactivation* signal, fired once per lifetime — not per call. So the ~312 B
+   the slice targeted was already gone.
+
+   Measuring the real activation-scoped residual by type (in-process `GCAllocationTick` listener,
+   `AllocByTypeProfiler`) showed the largest *reducible* bucket was **async state-machine boxes**
+   (`AsyncValueTaskMethodBuilder` continuation boxes on the dispatch hot path), ~470 B/call. Fixed by
+   annotating the hot async methods with `[AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]`
+   / `PoolingAsyncValueTaskMethodBuilder<>`:
+   `LocalGrainCallInvoker.InvokeVoidAsync`/`InvokeAsync`, and `GrainActivation.PostCoreAsync<TState>`
+   / `PostCoreAsync<TState,TResult>` / `PostCoreAsync` (non-generic). Boxes are now rented from the
+   builder's per-thread pool and returned on completion.
+
+   Measured (`AllocByTypeProfiler`, workstation GC): activation-scoped **1013 B/call → 585 B/call
+   (−428 B, −42%)**; the async-box types disappear from the top-15 entirely. Throughput up (~670k vs
+   ~588k calls/s over 5 s). Full unit suite green (548/550; the 2 failures are wall-clock reminder
+   timing tests flaky under full-suite CPU load, pass in isolation, and don't touch the dispatch path).
+
+   Residual 585 B is now dominated by **scheduler-side** costs, not dispatch:
+   `SemaphoreSlim.WaitUntilCountOrTimeoutAsync` (159 B — legacy-scheduler park/wake; ArenaScheduler
+   avoids it), `TaskNode` (86 B), `StatelessWorkerPoolPolicy` closure (60 B),
+   `GetOrActivateAsync`'s `<>c__DisplayClass26_0` capture (52 B — clean follow-up, deferred for
+   activation-table concurrency safety), `CompletionActionInvoker` (32 B). Slices (b) MPSC ring and
+   (c) payload slabs remain; much of the original 742 B mailbox estimate is already reclaimed.
+
+   **Slice (b) — DONE (2026-07-13), REDIRECTED away from the MPSC ring.** Before writing the ring,
+   the residual was re-measured by *full* type name (`AllocByTypeProfiler`, disambiguating `Boolean]`
+   → `AsyncStateMachineBox[…]`, etc.). Ground truth: **zero `System.Threading.Channels.*` allocation
+   in the residual.** The `Channel` lanes with pooled work items are already allocation-free per op at
+   steady state, so a Vyukov MPSC ring replacing them would reclaim ~0 measurable bytes — slice (a) +
+   the pooling builder had already absorbed the mailbox-async bucket the original 742 B estimate
+   attributed to Part B. The whole 585 B was **scheduler + placement + activation-table**, not the
+   mailbox. Rather than ship a large lock-free rewrite against a dead target, slice (b) fixed the three
+   real allocators on the dispatch hot path:
+
+   1. **`StatelessWorkerRouter.TryGetPolicy`** passed the `ResolvePolicy` *instance* method group to
+      `ConcurrentDictionary.GetOrAdd` on every call, allocating a fresh `Func<GrainType,
+      StatelessWorkerPoolPolicy?>` delegate per call even on cache hits — and it runs for *every* grain
+      call (non-stateless-worker grains cache a null policy). Fixed by caching the delegate in a field
+      (`_resolvePolicy`). **−65 B/call, all grains.**
+   2. **`LocalGrainCallInvoker.GetOrActivateAsync`** allocated `() => CreateActivationAsync(grainId,
+      ct)` (a `<>c__DisplayClass` + `Func<ValueTask<GrainActivation>>`) before `GetOrCreateAsync`'s
+      fast path ran, so it was paid on every cache hit. Added a state-passing
+      `GrainActivationTable.GetOrCreateAsync<TState>` overload (static delegate + struct-tuple state,
+      identical `Lazy<Task>` dedup semantics; the `Lazy` closure is created only on a miss). **−111
+      B/call.**
+   3. **`ActivationScheduler.RunWorkerAsync`** parked idle workers on `SemaphoreSlim.WaitAsync(ct)`,
+      whose slow path allocates an `AsyncStateMachineBox` + `CancellationPromise<bool>` (+ downstream
+      `TaskNode`/`CompletionActionInvoker`) — ~380 B/call in a hot ping-pong where the worker parks and
+      wakes ~once per call. Added a **bounded, unregistered spin-before-park**: re-check the shards for
+      a few microseconds (until `SpinWait.NextSpinWillYield`) before registering idle or parking. Under
+      load the next item lands inside the spin window so the worker never parks (no alloc, lower
+      latency); a genuinely idle system exhausts the spin and parks promptly (no busy-wait). The spin
+      is pure optimism in front of the original push-idle → re-check → park race guard, so the lost-wake
+      invariant is unchanged. **−~380 B/call.**
+
+   Cumulative (`AllocByTypeProfiler`, workstation GC): activation-scoped **585 → 38 B/call (−93.5%)**;
+   per-call **1383 → 1003 B/call** (fixes 1+3 are on the common dispatch path, so the default
+   `IGrainBehavior` path benefits too — its residual is the Part-A DI bucket). Throughput on the
+   activation-scoped path ~+65% in the 6 s window. Clean Release build, 0 warnings. All 44
+   scheduling-semantics/stuck-detector tests pass deterministically; the remaining full-suite failures
+   are pre-existing wall-clock timing flakes (verified to fail identically with the spin **disabled**,
+   so the spin does not worsen them).
+
+   The last **~33 B/call** was a `ConcurrentStack<int>.Node` from `_idleWorkers.Push(workerIndex)` on
+   each shard-empty transition. **DONE (2026-07-13):** replaced the `ConcurrentStack<int>` idle registry
+   with a lock-free `long[]` **bitmask** (`_idleBits`; bit i = worker i idle). `RegisterIdle` is one
+   `Interlocked.Or` (allocation-free, idempotent — one bit per worker vs the stack's possible duplicate
+   entries); `TryClaimIdleWorker` scans words and claims the lowest set bit via per-word CAS (retrying a
+   lost race). The `Interlocked.Or`/`CompareExchange` are full barriers, so the wake-race happens-before
+   argument is identical to the stack's; the multi-word layout covers >64-core machines. The
+   `Node[System.Int32]` type is now **absent** from the allocation profile. Correctness: 48
+   scheduling/mailbox/stuck tests + 550/550 unit + 38/38 integration (incl. the #167 grain-to-grain
+   fan-in wake path) all green; tens of millions of park/wake cycles across the profiler runs completed
+   without a lost wake (which would stall throughput).
+
+   **Regime nuance discovered while measuring the bitmask.** The activation-scoped residual is
+   **bimodal**, governed by whether the spin-before-park catches the next item:
+   - **Spin-catch regime** (quiet/fast box, round-trip < spin window ≈ sub-µs): the worker never parks;
+     residual ≈ **1–2 B/call** (true zero — the bitmask removed the last idle-registration byte).
+   - **Park regime** (loaded box, round-trip ≳ 1 µs > spin window): the worker parks on
+     `SemaphoreSlim.WaitAsync(ct)`, whose slow path allocates ~200 B (`AsyncStateMachineBox` +
+     `CancellationPromise` + `TaskNode` + `CompletionActionInvoker`). The bitmask still saves its 33 B
+     here (park machinery ~200 B, vs ~233 B with the old stack), but the park machinery dominates.
+
+   So the spin-before-park's near-zero is real but **load-sensitive**: it eliminates the park (and its
+   ~200 B) only when the next message arrives inside the spin window. The remaining frontier is the park
+   mechanism itself — either a longer/adaptive spin (CPU-vs-alloc tradeoff), or a pooled/token-free wake
+   primitive replacing `SemaphoreSlim.WaitAsync(ct)` (its `CancellationPromise` + `AsyncStateMachineBox`
+   are the bulk), or ArenaScheduler's wake design. That is a scheduler-park change, tracked separately.
+
+   **Slice (c) (payload slabs) is moot** — the `MailboxWorkItem<T>` boxing it targeted is already
+   <2 B/call. The MPSC ring / `MessageHandle` design is retained below for reference but is not being
+   built: the Channel is not the allocator.
+
+   **Park primitive — DONE (2026-07-13).** The park-regime ~200 B was eliminated by replacing the
+   per-worker `SemaphoreSlim(0, int.MaxValue)` with **`WorkerParkSignal`** — a single-consumer /
+   multi-producer async auto-reset event backed by a reusable `ManualResetValueTaskSourceCore<bool>`
+   (`src/Quark.Runtime/WorkerParkSignal.cs`). A park now allocates **nothing**: the worker's async
+   state-machine box already exists for the life of `RunWorkerAsync` (allocated once on first
+   suspension, reused every park), and `WaitAsync()` hands it a bare `ValueTask` backed by the reusable
+   source. The wait is **token-free** (dropping `SemaphoreSlim.WaitAsync(ct)`'s per-park
+   `CancellationPromise<bool>` + registration node); `DisposeAsync` `Set()`s every worker on shutdown so
+   each observes the cancelled token and exits, mirroring `ArenaScheduler`.
+
+   A three-state field (`Idle`/`Signaled`/`Waiting`) mutated only by CAS mediates every producer/consumer
+   transition, so the value-task core is touched by at most one thread at a time. A **boolean** auto-reset
+   event is a sound replacement for the permit-counting semaphore because the scheduler's wake is
+   *edge-triggered*: after one wake a worker re-sweeps every shard until a sweep is empty, so a single
+   signal drains arbitrarily many ready activations — collapsing concurrent `Set()`s only elides redundant
+   no-op sweeps, it can never strand work. Verified: 20 M multi-producer/consumer cycles through a faithful
+   standalone model of the exact wake protocol (register-idle → claim-bit → `Set`) with zero lost wakes.
+
+   Measured (`AllocByTypeProfiler`, workstation GC, **park regime** — the loaded-box case that previously
+   cost ~200 B): activation-scoped **~200 → 1.3–1.9 B/call**; the only residual entries are the pooled
+   `MailboxWorkItem<T>` (~1.5 B) and a stray `object[]` (~0.3 B). The park machinery is entirely gone from
+   the profile in both regimes.
+
+   **Latent dispose-hang uncovered and fixed (same session).** Swapping the primitive surfaced a
+   pre-existing bug: `ActivationScheduler.ScheduleAsync` (since the `Channel<GrainActivation>` →
+   `ConcurrentQueue` rewrite) no longer rejected work after shutdown. During `ServiceProvider` disposal the
+   scheduler is disposed *before* `GrainActivationTable`, so when the table then disposes each activation,
+   `GrainActivation.DisposeAsync` posts its `OnDeactivate` turn through `ScheduleAsync` and awaits the
+   drain — but the drain workers have already exited, so the enqueue sat undrained and the poster hung
+   forever. The old `Channel` ready queue threw `ChannelClosedException` here, which drove the activation's
+   inline-drain fallback (`DrainDirectlyAndDeactivateAsync`); the `ConcurrentQueue` has no closed state, so
+   the fallback became dead code. It stayed invisible only because the departing `SemaphoreSlim` park
+   primitive *disposed its semaphores*, so the post-shutdown `Release()` threw `ObjectDisposedException` for
+   an unrelated reason and accidentally drove the same fallback. `WorkerParkSignal.Set()` has nothing to
+   dispose, removing that accident. **Fix:** `ScheduleAsync` now throws `ObjectDisposedException` when
+   `_cts.IsCancellationRequested` (a single hot-path volatile read, only ever true during shutdown),
+   restoring the reject-on-shutdown contract explicitly. `ScheduleAsync` is `async`, so the throw surfaces
+   as a faulted `ValueTask` — `PostCoreAsync`'s `await` propagates it to the fallback, and `Deactivate()`'s
+   `OnlyOnFaulted` continuation absorbs it. Locked in by `ActivationSchedulerShutdownRejectsScheduleTests`
+   (2 tests; both fail — the second by hanging to a 10 s timeout — with the guard removed). Correctness:
+   scheduling-semantics 45/45, Fault 9/9, Integration 38/38, unit 549–550/550 (the 1–2 residual failures
+   are the documented wall-clock timing flakes that shift across runs and pass in isolation). Clean Release
+   build, 0 warnings.
+
+## Open questions
+
+- **Reentrant + activation state:** do we require `IActivationBehavior` reentrant grains to opt into
+  their own synchronization, or forbid mutable fields on reentrant activation behaviors outright
+  (harder QRK0023 = error)?
+- **`IActivationMemory<T>` on an `IActivationBehavior`:** allowed (redundant with fields) or
+  discouraged? Leaning: allowed, since durable (`IPersistentActivationMemory<T>`) and managed
+  (`IManagedActivationMemory<T>`) variants are still useful there.
+- **Payload slab sizing / per-type pool caps** — needs a follow-up once Part B (a)/(b) land and we
+  can measure descriptor churn under load.
+- **`ArenaScheduler` reject-on-shutdown (opt-in path):** `ArenaScheduler.ScheduleAsync` has the same
+  latent "silently accepts work after shutdown" gap the default scheduler had, currently masked the same
+  accidental way (it disposes its per-worker semaphores, so a post-shutdown `Release()` throws
+  `ObjectDisposedException` and drives the activation's inline-drain fallback). It should get the same
+  explicit guard — but its `ScheduleAsync` returns synchronously, so the guard must be
+  `return ValueTask.FromException(...)` (not `throw`) to keep `Deactivate()`'s
+  `ValueTask vt = ScheduleAsync(...)` assignment from throwing into a `void` caller. Deferred: ArenaV2 is
+  opt-in and out of scope for the park-primitive change.

--- a/docs/superpowers/specs/2026-07-13-scheduler-v2-pingpong-cost-profile.md
+++ b/docs/superpowers/specs/2026-07-13-scheduler-v2-pingpong-cost-profile.md
@@ -1,0 +1,203 @@
+# ArenaScheduler (V2) — PingPong CPU cost profile
+
+**Date:** 2026-07-13
+**Trace:** `dotnet-trace` (`Microsoft-DotNETCore-SampleProfiler`, managed thread-time, ~100 Hz stacks)
+**Workload:** `PingPong --v2 --pairs 32 --duration 15` — 32 ping/pong pairs (64 activations), non-reentrant, in-process `TestCluster`, one silo.
+**Machine:** 32 logical cores, Linux, .NET 10 (`10.0.201`).
+**Raw artifacts:** `pingpong-v2.speedscope.json` (39 MB) + aggregation scripts in the session scratchpad.
+
+> **How to read this.** The sample profiler tags every leaf with a synthetic `CPU_TIME` (on-CPU) or `UNMANAGED_CODE_TIME` (blocked in a syscall/park) pseudo-frame. Numbers below re-attribute that time to the *real* method one frame up, and split **on-CPU work** (813 s of thread-time) from **parked/waiting** time (556 s). Percentages are of the 813 s on-CPU pool unless noted — this is where the machine actually burns cycles.
+
+---
+
+## Headline
+
+**63% of on-CPU time is overhead, not dispatch work** — GC coordination and lock contention, not running grain methods.
+
+| | on-CPU share | what it is |
+|---|---:|---|
+| GC safepoint polling (`PollGCWorker`) | **38.8%** | threads rendezvousing for GC — allocation-driven |
+| `Monitor.Enter_Slowpath` (lock contention) | **24.6%** | one hot `SemaphoreSlim` + the DI container lock |
+| Everything else (actual dispatch + park) | 36.6% | invoker, mailbox, DI resolve, behavior call |
+
+The single biggest lever is **GC**, and it's a one-line config change today:
+
+| Config (same build, same workload) | calls/s | Δ |
+|---|---:|---:|
+| Workstation GC (current default) | 326,622 | baseline |
+| **Server GC** (`DOTNET_gcServer=1`) | **560,282** | **+72%** |
+
+Server GC gives per-core heaps and background collection, so the 32 workers stop stalling at shared GC safepoints. The trace above was captured under workstation GC, which is why `PollGCWorker` dominates — **treat the 38.8% as "recoverable by GC config + allocation cuts," not as fixed cost.**
+
+---
+
+## 1. On-CPU exclusive (self) time — top costs
+
+| self time | % CPU | method | verdict |
+|---:|---:|---|---|
+| 315.5 s | 38.8% | `Thread.PollGCWorker` | GC rendezvous — allocation pressure (see §4) |
+| 199.9 s | 24.6% | `Monitor.Enter_Slowpath` | lock contention (see §2) |
+| 54.6 s | 6.7% | `ThreadPool.WorkerThreadStart` | ThreadPool spin-up for async-resume spill |
+| 43.5 s | 5.3% | `Thread.Sleep` | spin-then-sleep in park/steal backoff |
+| 36.3 s | 4.5% | `LowLevelLifoSemaphore.WaitForSignal` | ThreadPool worker parking |
+| 21.5 s | 2.6% | `LowLevelLifoSemaphore.Wait` | idem |
+| 13.5 s | 1.7% | `LowLevelSpinWaiter.Wait` | spin before park |
+| 11.3 s | 1.4% | `CancellationTokenSource.EnterLock` (contention) | CT registration on every `SemaphoreSlim.Wait(ct)` (see §2) |
+| 10.2 s | 1.3% | `ArenaScheduler.WorkerLoop` | scheduler outer loop (our code) |
+| 9.4 s | 1.2% | `SpinWait.SpinOnce` | park/steal backoff |
+| 8.5 s | 1.0% | DI `Dictionary` lookup (`ServiceLookup`) | per-call service resolution |
+| 7.6 s | 0.9% | `LocalGrainCallInvoker.InvokeVoidAsync` state machine | our dispatch |
+| 3.2 s | 0.4% | DI `ResolveService` (stub) | per-call resolution |
+
+The Quark methods that show up as *self* time are small (`WorkerLoop` 1.3%, `InvokeVoidAsync` 0.9%). **Our own code is cheap; the cost is in what it makes the runtime do** — GC, locks, ThreadPool hops.
+
+---
+
+## 2. Lock contention — `Monitor.Enter_Slowpath` (24.6% CPU)
+
+Attributing the contended-monitor time to its immediate caller (253.8 s total sampled at the slow-path):
+
+| share | caller entering the monitor | which lock |
+|---:|---|---|
+| 37.5% | `SemaphoreSlim.WaitCore` | **worker park signal** (`_signals[i]`) |
+| 31.0% | `SemaphoreSlim.Release` | **worker wake** (same semaphores) |
+| 24.1% | DI `ResolveService` | **DI container realized-services lock** |
+| 3.1% | `SingleConsumerUnboundedChannel.Writer` | mailbox lane enqueue |
+| 0.9% | DI scope `BeginDispose` | per-call scope teardown |
+
+### 2a. The park/wake `SemaphoreSlim` — ~68% of contention (~174 s)
+
+`ArenaScheduler` parks each worker on a per-worker `SemaphoreSlim` and wakes it with `Release()`:
+
+- `src/Quark.Runtime/Scheduling/ArenaScheduler.cs:72` — `private readonly SemaphoreSlim[] _signals;`
+- `:259` — worker parks: `_signals[index].Wait(ct)`
+- `:211` — producer wakes: `_signals[worker].Release()`
+- `:419`, `:444` — in-flight-cap park/wake on the same semaphores
+
+`SemaphoreSlim` takes an **internal `Monitor`** on both `Wait` and `Release`. At this wake rate (hundreds of thousands/s) the wait side (worker) and release side (32 driver/producer threads) collide on that monitor — hence the 68% split across `WaitCore` + `Release`.
+
+Compounding it: **`Wait(ct)` registers a callback on the `CancellationToken` every single park** → the `CancellationTokenSource.EnterLock` contention (1.4% CPU, §1) and `Registrations.Unregister` on wake. The token is only ever used for shutdown, which already `Release()`s every signal explicitly (`:479`).
+
+**Improvement candidates (highest expected payoff):**
+1. Replace `SemaphoreSlim` with a lighter park primitive — a kernel `Semaphore`, an `AutoResetEvent`, or a ported `LowLevelLifoSemaphore` (what the CLR ThreadPool itself uses to avoid exactly this). Lock-free fast path, no managed monitor.
+2. Drop the `CancellationToken` from the hot `Wait` — park token-free, observe the existing `_cts`/shutdown `Release()` for exit. Removes per-park CT registration + its lock.
+
+### 2b. DI `ResolveService` lock — ~24% of contention (~61 s)
+
+Every non-reentrant call resolves the behavior (and two runtime services — `AddQuarkRuntime` registrations #3 and #5) from a **fresh per-call scope**. `Microsoft.Extensions.DependencyInjection`'s default provider takes a lock around its realized-services / call-site cache. 32 workers resolving concurrently serialize here.
+
+**Improvement candidates:**
+1. Resolve fewer services per call — cache the two per-call runtime services on the activation/shell if they're effectively singletons or scope-invariant.
+2. Cache the compiled behavior factory per grain-type and invoke it directly, bypassing generic `ResolveService` (the generator already knows the concrete behavior type — a typed factory delegate avoids the container's locked lookup).
+3. Longer term: a purpose-built per-call scope that doesn't hit the shared realized-services dictionary.
+
+---
+
+## 3. Dispatch-path inclusive cost (where a call's time goes)
+
+Inclusive on-CPU time for each stage of one grain call (frames overlap — inclusive = self + all callees):
+
+| inclusive | % CPU | stage | file |
+|---:|---:|---|---|
+| 406.4 s | 50.0% | `ArenaScheduler.WorkerLoop` (whole worker side) | `ArenaScheduler.cs:216` |
+| 218.3 s | 26.9% | `RunActivation` (turn body) | `ArenaScheduler.cs:321` |
+| 174.3 s | 21.4% | `LocalGrainCallInvoker.InvokeVoidAsync` (call path) | `LocalGrainCallInvoker.cs` |
+| 173.0 s | 21.3% | `GrainActivation.PostCoreAsync` (enqueue + wake) | `GrainActivation.cs` |
+| 147.5 s | 18.1% | `DrainAndCompleteAsync` | `GrainActivation.cs` |
+| 124.1 s | 15.3% | `MailboxWorkItem.ExecuteAsync` (runs behavior + signals completion) | `GrainActivation.cs` |
+| 90.8 s | 11.2% | **DI `ResolveService`** | M.E.DI |
+| 42.3 s | 5.2% | `GrainScopeBinder.BindAndResolve` | `GrainScopeBinder.cs` |
+| 18.4 s | 2.3% | DI `CreateInstance` (behavior ctor via invoke-stub) | M.E.DI |
+| 18.1 s | 2.2% | **`Stopwatch.GetTimestamp`** | diagnostics per-call timing |
+| 4.4 s | 0.5% | scope `Dispose` | M.E.DI |
+
+Notes:
+- **DI is ~13.5% inclusive** across resolve + bind + ctor + dispose — the largest *non-overhead* consumer, and it holds the contended lock in §2b. This is the top algorithmic target after GC and park/wake.
+- **`Stopwatch.GetTimestamp` = 2.2%** — per-call invocation timing (`clock_gettime` syscall). Worth gating behind "is any diagnostic listener actually subscribed" so a no-op listener costs zero. (The PingPong harness registers `BenchmarkDiagnosticListener`, so this is partly a benchmark artifact, but real deployments with a listener pay it too.)
+- `GetOrActivateAsync` (activation-table lookup) is **0.6%** — the `ConcurrentDictionary` grain lookup is not a bottleneck.
+
+---
+
+## 4. GC pressure (the 38.8%)
+
+`PollGCWorker` is where threads stall at safepoints while a GC is pending; its callers are spread across every allocating dispatch method (`RunActivation` 17%, `PostCoreAsync` 6.7%, `CreateInstance`, dictionary lookups, buffer copies). That distribution = **high steady allocation rate**, not one bad allocation.
+
+Per non-reentrant call we currently allocate, at minimum: a fresh `IServiceScope`, the behavior instance, several async state machines (`InvokeVoidAsync`, `PostCoreAsync`, `MailboxWorkItem.ExecuteAsync`, `DrainAsync`), the closure(s) captured for the mailbox `Func<ValueTask>`, and the completion-signal object.
+
+See §4a for the measured per-call byte decomposition that turns this into a ranked plan.
+
+---
+
+## 4a. Allocation profile — measured B/call (`[MemoryDiagnoser]`, `DispatchPipelineBenchmarks`)
+
+CPU sampling tells us *where cycles go*; this tells us *where bytes go*. Exact managed allocation per pipeline stage on the real `LocalGrainCallInvoker` path (PingPong behavior, both `--job short` and 5-iteration runs agree):
+
+| stage | B/call | reading |
+|---|---:|---|
+| `ActivationTableLookup` | **0** | grain lookup is allocation-free |
+| `ExecutionContextCapture` | **0** | not a target |
+| `MailboxRoundTripReentrant` | **0** | inline turn — the baseline |
+| `ServiceScopeCreateDispose` | 128 | bare `root.CreateScope()` |
+| `ScopeBindAndResolve` | **792** | scope + 4 DI resolutions + behavior construct |
+| `MailboxRoundTrip` (non-reentrant) | **742** | channel write + scheduler wake + completion signal |
+| `ChannelSignalPattern` | 312 | the forced-async completion signal alone |
+| **`FullInvokeVoidAsync` (total)** | **2039** | **the whole call** |
+
+**The 2039 B/call splits into three buckets:**
+
+| bucket | B/call | share | notes |
+|---|---:|---:|---|
+| **DI scope + resolution** | **792** | **38.8%** | 128 B scope + 664 B resolving the per-*activation* scoped services (shell accessor, call-context setter, memory accessors). Behavior is dep-free here, so ~none of it is the behavior instance. |
+| **Mailbox async machinery** | **742** | **36.4%** | `MailboxRoundTripReentrant`=0 B proves *all* of it is channel + scheduler + completion-signal, not the work. ~312 B is the forced-async signal. |
+| Outer invoke machinery | ~505 | 24.8% | outer state machine, `InvokeVoidState` box, diagnostics/activity. |
+
+At the server-GC rate (560k calls/s) that's **~1.14 GB/s** of garbage — the direct driver of the §4 GC-poll cost. Cutting the 792 B DI bucket alone drops it by ~39%.
+
+**Key correction to the earlier guess:** the invoker does **not** allocate a per-call closure — it already passes a `readonly struct` state (`InvokeVoidState<TInvokable>`) into a `static` mailbox lambda (`LocalGrainCallInvoker.cs:222`). So the mailbox 742 B is the async state machine + completion signal, not a captured delegate. The real targets are the **scope** and the **signal**, not a closure.
+
+**Ranked (byte-grounded):**
+1. **Server GC** — free +72% throughput (doesn't cut bytes, cuts the poll cost). *(config, trivial)*
+2. **Treat the activation as the scope** — cache the per-activation scoped deps (shell accessor, call-context setter, `IActivationMemory<T>` accessors) on the shell and skip `root.CreateScope()` on the fast path. Reclaims the whole **792 B (39%)** *and* removes the DI-resolution lock from §2b. *(medium; call-context must still bind per call)*
+3. **Pooled completion signal** — replace the per-call `TaskCompletionSource` with a reusable `IValueTaskSource`. Reclaims ~**312 B (15%)**. *(medium; single-await discipline)*
+4. **Struct/pooled work-item state machine** for the rest of the mailbox path — ~**430 B (21%)**. *(high; async-resume correctness)*
+5. **Singleton dep-free behaviors** (generator knows ctor arity → one shared instance, no construction) + gate `Stopwatch.GetTimestamp`/activity when no listener is subscribed. *(low)*
+
+Pooling the *behavior instance* (the original hypothesis) is **not** on this list: `ScopeBindAndResolve`=792 B for a dependency-free behavior shows the instance is a negligible slice, and pooling is unsafe once a behavior has injected (activation-bound) deps. The scope — not the behavior — is the garbage.
+
+---
+
+## 5. Parked / waiting time (556 s, informational)
+
+Not on-CPU cost — this is threads correctly asleep. Breakdown: `LowLevelLifoSemaphore.WaitForSignal` 38% (ThreadPool workers idle), `WaitNative` 22%, `Monitor.Wait` 17% (SemaphoreSlim timed waits + console logger + `ManualResetEventSlim`), `Monitor.Enter_Slowpath` 10% (blocked, not spinning, on the park semaphore — the §2a lock again, from the other side). Healthy except that the §2a semaphore also shows up here: fixing it reclaims both the spinning (§2) and some of this blocking.
+
+---
+
+## Ranked backlog (for review)
+
+| # | Change | Expected | Effort | Risk |
+|---|---|---|---|---|
+| 1 | Default/recommend **Server GC** for silos | **+~70%** measured throughput | trivial (config/doc) | none |
+| 2 | **Treat the activation as the scope** — cache per-activation scoped deps on the shell, skip `CreateScope()` per call | **~792 B/call (39% of alloc)** + removes DI-resolve lock (§2b) | medium | call-context must still bind per call |
+| 3 | Replace park/wake `SemaphoreSlim` with low-level semaphore; **drop `ct` from hot `Wait`** | cut most of 24.6% lock CPU | medium | scheduler correctness — needs the concurrency-stress + lost-wake tests |
+| 4 | **Pooled completion signal** (`IValueTaskSource` for the mailbox turn) | ~312 B/call (15% of alloc) | medium | ValueTask single-await discipline |
+| 5 | **Struct/pooled work-item state machine** (rest of mailbox path) | ~430 B/call (21% of alloc) | high | async-resume correctness, keep priority lanes working |
+| 6 | **Singleton dep-free behaviors** + gate `Stopwatch.GetTimestamp`/activity behind active-listener check | small alloc + ~2% CPU | low | diagnostics fidelity |
+
+**Suggested sequence:** #1 (free, do now) → measure → **#2 (biggest single allocation bucket + kills a lock)** → #3 (park/wake lock) → #4/#5 (mailbox allocations). Re-run this exact trace + the `DispatchPipelineBenchmarks` allocation numbers after each to confirm the shift.
+
+> Note: pooling the *behavior instance* is deliberately **not** in this list — see §4a. The behavior is a negligible allocation slice and pooling is unsafe once it has injected deps; the per-call **scope** (#2) is the real garbage.
+
+### Reproduce
+
+```bash
+dotnet build -c Release tests/Quark.Performance/Quark.Performance.csproj
+DLL=tests/Quark.Performance/bin/Release/net10.0/Quark.Performance.dll
+dotnet-trace collect --format Speedscope --profile dotnet-sampled-thread-time \
+  -- dotnet "$DLL" PingPong --v2 --duration 15 --pairs 32
+# GC A/B:
+DOTNET_gcServer=0 dotnet "$DLL" PingPong --v2 --duration 10 --pairs 32
+DOTNET_gcServer=1 dotnet "$DLL" PingPong --v2 --duration 10 --pairs 32
+# Per-call allocation decomposition (§4a):
+dotnet run -c Release --project tests/Quark.Performance -- \
+  --filter "*DispatchPipelineBenchmarks*" --job short --memory
+```

--- a/src/Quark.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Quark.Analyzers/AnalyzerReleases.Unshipped.md
@@ -14,6 +14,7 @@
  QRK0020 | Quark.BehaviorLifecycle | Warning | Mutable instance field on grain behavior will be reset between calls
  QRK0021 | Quark.BehaviorLifecycle | Warning | Writable auto-property on grain behavior will be reset between calls
  QRK0022 | Quark.BehaviorLifecycle | Warning | Static mutable state on grain behavior is shared across all activations
+ QRK0023 | Quark.BehaviorLifecycle | Warning | IActivationBehavior is not supported on a reentrant grain
  QRK0030 | Quark.Performance    | Warning | Grain behavior method returns Task; consider ValueTask
  QRK0031 | Quark.Performance    | Info    | Use ValueTask-native completion instead of Task.CompletedTask/Task.FromResult
  QRK0040 | Quark.Reentrancy     | Warning | Non-reentrant grain behavior awaits a call back into its own grain interface

--- a/src/Quark.Analyzers/BehaviorStateAnalyzer.cs
+++ b/src/Quark.Analyzers/BehaviorStateAnalyzer.cs
@@ -8,22 +8,31 @@ namespace Quark.Analyzers;
 ///     Warns when a grain behavior class stores mutable per-instance state in fields or
 ///     writable auto-properties that survive only for the duration of one call.
 ///     <list type="bullet">
-///         <item>QRK0020 (Warning) — non-readonly instance field on a behavior class.</item>
-///         <item>QRK0021 (Warning) — writable auto-property on a behavior class.</item>
+///         <item>QRK0020 (Warning) — non-readonly instance field on a per-call behavior class.</item>
+///         <item>QRK0021 (Warning) — writable auto-property on a per-call behavior class.</item>
 ///         <item>QRK0022 (Warning) — mutable static field/property on a behavior class.</item>
+///         <item>QRK0023 (Warning) — <c>IActivationBehavior</c> on a <c>[Reentrant]</c> grain.</item>
 ///     </list>
 /// </summary>
 /// <remarks>
-///     Quark constructs a fresh <c>IGrainBehavior</c> instance per grain method invocation.
-///     Any value written to an instance field or property during call N is gone by call N+1.
-///     Cross-call state must be stored in <c>IActivationMemory&lt;T&gt;</c> (in-memory),
-///     <c>IManagedActivationMemory&lt;T&gt;</c> (async-init resources, e.g. timer handles),
-///     or <c>IPersistentActivationMemory&lt;T&gt;</c> (durable storage).
+///     Quark constructs a fresh <c>IGrainBehavior</c> instance per grain method invocation, so any value
+///     written to an instance field or property during call N is gone by call N+1. Cross-call state must
+///     be stored in <c>IActivationMemory&lt;T&gt;</c> (in-memory),
+///     <c>IManagedActivationMemory&lt;T&gt;</c> (async-init resources, e.g. timer handles), or
+///     <c>IPersistentActivationMemory&lt;T&gt;</c> (durable storage).
+///     <para>
+///         A behavior that opts into <c>IActivationBehavior</c> instead lives for the whole activation
+///         (one instance reused across calls), so mutable instance fields/properties are intentional and
+///         QRK0020/QRK0021 do not apply to it. Mutable <i>static</i> state (QRK0022) is still shared
+///         across every activation on the silo and is flagged for both models.
+///     </para>
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class BehaviorStateAnalyzer : DiagnosticAnalyzer
 {
     private const string IGrainBehaviorFqn = "Quark.Core.Abstractions.Grains.IGrainBehavior";
+    private const string IActivationBehaviorFqn = "Quark.Core.Abstractions.Grains.IActivationBehavior";
+    private const string ReentrantAttributeFqn = "Quark.Core.Abstractions.Grains.ReentrantAttribute";
 
     public static readonly DiagnosticDescriptor MutableInstanceField = new(
         "QRK0020",
@@ -60,8 +69,20 @@ public sealed class BehaviorStateAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         helpLinkUri: "https://github.com/thnak/Quark/wiki/AOT-and-Trim");
 
+    public static readonly DiagnosticDescriptor ReentrantActivationBehavior = new(
+        "QRK0023",
+        "IActivationBehavior is not supported on a reentrant grain",
+        "Grain behavior '{0}' implements IActivationBehavior and is [Reentrant]. Per-activation behaviors " +
+        "are not supported on reentrant grains — a single shared instance under concurrent (interleaved) " +
+        "turns has no per-turn call-context isolation, and activating one throws at runtime. " +
+        "Remove [Reentrant], or drop IActivationBehavior to use the per-call model.",
+        "Quark.BehaviorLifecycle",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: "https://github.com/thnak/Quark/wiki/AOT-and-Trim");
+
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        ImmutableArray.Create(MutableInstanceField, WritableAutoProperty, MutableStaticState);
+        ImmutableArray.Create(MutableInstanceField, WritableAutoProperty, MutableStaticState, ReentrantActivationBehavior);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -79,22 +100,42 @@ public sealed class BehaviorStateAnalyzer : DiagnosticAnalyzer
             return;
 
         bool isGrainBehavior = false;
+        bool isActivationBehavior = false;
         foreach (INamedTypeSymbol iface in type.AllInterfaces)
         {
-            if (iface.ToDisplayString() == IGrainBehaviorFqn)
+            // IActivationBehavior extends IGrainBehavior, so an activation behavior has both in
+            // AllInterfaces — isGrainBehavior is set either way.
+            switch (iface.ToDisplayString())
             {
-                isGrainBehavior = true;
-                break;
+                case IGrainBehaviorFqn:
+                    isGrainBehavior = true;
+                    break;
+                case IActivationBehaviorFqn:
+                    isActivationBehavior = true;
+                    break;
             }
         }
 
         if (!isGrainBehavior)
             return;
 
+        // QRK0023 — per-activation behaviors are not supported on reentrant grains (they throw at
+        // activation). Surface it at build time rather than as a runtime NotSupportedException.
+        if (isActivationBehavior && HasReentrantAttribute(type))
+        {
+            ctx.ReportDiagnostic(Diagnostic.Create(
+                ReentrantActivationBehavior,
+                type.Locations.FirstOrDefault() ?? Location.None,
+                type.Name));
+        }
+
         foreach (ISymbol member in type.GetMembers())
         {
-            // Non-static, non-const, non-readonly instance fields → QRK0020
-            if (member is IFieldSymbol field &&
+            // Non-static, non-const, non-readonly instance fields → QRK0020.
+            // Suppressed for IActivationBehavior: the instance lives for the whole activation, so its
+            // fields are legitimate per-activation state (they persist across calls).
+            if (!isActivationBehavior &&
+                member is IFieldSymbol field &&
                 !field.IsStatic &&
                 !field.IsConst &&
                 !field.IsReadOnly)
@@ -106,8 +147,10 @@ public sealed class BehaviorStateAnalyzer : DiagnosticAnalyzer
                     type.Name));
             }
 
-            // Auto-properties with a non-init writable setter → QRK0021
-            if (member is IPropertySymbol property &&
+            // Auto-properties with a non-init writable setter → QRK0021. Suppressed for
+            // IActivationBehavior for the same reason as QRK0020.
+            if (!isActivationBehavior &&
+                member is IPropertySymbol property &&
                 !property.IsStatic &&
                 !property.IsReadOnly &&
                 property.SetMethod is { } setter &&
@@ -150,6 +193,17 @@ public sealed class BehaviorStateAnalyzer : DiagnosticAnalyzer
                     type.Name));
             }
         }
+    }
+
+    private static bool HasReentrantAttribute(INamedTypeSymbol type)
+    {
+        foreach (AttributeData attr in type.GetAttributes())
+        {
+            if (attr.AttributeClass?.ToDisplayString() == ReentrantAttributeFqn)
+                return true;
+        }
+
+        return false;
     }
 
     // Types whose value can never change after construction, so a `static readonly` field

--- a/src/Quark.Core.Abstractions/Grains/IActivationBehavior.cs
+++ b/src/Quark.Core.Abstractions/Grains/IActivationBehavior.cs
@@ -1,0 +1,29 @@
+namespace Quark.Core.Abstractions.Grains;
+
+/// <summary>
+///     Opts a grain behavior into <b>per-activation</b> lifetime instead of the default per-call model.
+///     One instance is constructed when the activation is created, reused for every call on that
+///     activation, and disposed on deactivation — versus <see cref="IGrainBehavior" />, which constructs
+///     (and discards) a fresh instance for every grain method call.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Because the instance lives for the whole activation, it may hold mutable per-activation state
+///         directly in instance fields — they persist across calls, the way an Orleans grain's fields do.
+///         The <c>QRK0020</c>/<c>QRK0021</c> analyzer rules (which forbid mutable state on the per-call
+///         model) therefore do not apply here. Mutable <i>static</i> state (<c>QRK0022</c>) is still
+///         shared across every activation on the silo and remains disallowed.
+///     </para>
+///     <para>
+///         Constructor dependencies are resolved once from a single activation-lifetime service scope,
+///         eliminating the per-call scope creation and DI resolution the default model pays on every
+///         call. Per-call context (for example the idempotency key exposed through
+///         <see cref="Quark.Core.Abstractions.Hosting.ICallContext" />) is still refreshed per call.
+///     </para>
+///     <para>
+///         <b>Not yet supported on <c>[Reentrant]</c> grains.</b> A shared instance under concurrent
+///         (interleaved) turns needs a per-turn call-context strategy this opt-in does not yet provide;
+///         activating a reentrant behavior that also implements this interface throws.
+///     </para>
+/// </remarks>
+public interface IActivationBehavior : IGrainBehavior;

--- a/src/Quark.Core.Abstractions/Scheduling/ActorPriority.cs
+++ b/src/Quark.Core.Abstractions/Scheduling/ActorPriority.cs
@@ -1,0 +1,21 @@
+namespace Quark.Core.Abstractions.Scheduling;
+
+/// <summary>
+///     Relative scheduling priority of a whole activation (grain), governing which <em>actor</em> a
+///     worker runs next when several are ready — distinct from <see cref="MessagePriority"/>, which
+///     orders messages within one actor. Higher-priority activations are dispatched ahead of
+///     lower-priority ones. The scheduler resolves an activation's effective band as the maximum of its
+///     actor priority and the priority of its highest pending message, so an urgent message to a
+///     low-priority actor still schedules promptly.
+/// </summary>
+public enum ActorPriority : byte
+{
+    /// <summary>Scheduled only when no higher-priority activation is ready.</summary>
+    Low = 0,
+
+    /// <summary>The default for an activation with no declared priority.</summary>
+    Normal = 1,
+
+    /// <summary>Scheduled ahead of <see cref="Normal"/> and <see cref="Low"/> activations.</summary>
+    High = 2,
+}

--- a/src/Quark.Core.Abstractions/Scheduling/MessagePriority.cs
+++ b/src/Quark.Core.Abstractions/Scheduling/MessagePriority.cs
@@ -1,0 +1,23 @@
+namespace Quark.Core.Abstractions.Scheduling;
+
+/// <summary>
+///     Relative priority of a single message within a grain's mailbox. A grain's mailbox is a small set
+///     of FIFO lanes, one per value here; the runtime drains the highest-priority non-empty lane first,
+///     so a higher-priority message jumps ahead of lower-priority messages already queued for the same
+///     grain — but it never interrupts the turn already executing (priority is non-preemptive). Ordering
+///     within a single lane is strict arrival order (FIFO).
+/// </summary>
+public enum MessagePriority : byte
+{
+    /// <summary>Drained only when no higher lane has work. Background/maintenance calls.</summary>
+    Low = 0,
+
+    /// <summary>The default when a call specifies no priority.</summary>
+    Normal = 1,
+
+    /// <summary>Drained ahead of <see cref="Normal"/> and <see cref="Low"/>.</summary>
+    High = 2,
+
+    /// <summary>Drained ahead of every other lane. Reserve for latency-critical control messages.</summary>
+    Urgent = 3,
+}

--- a/src/Quark.Runtime/ActivationScheduler.cs
+++ b/src/Quark.Runtime/ActivationScheduler.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Numerics;
 using Quark.Diagnostics.Abstractions;
 
 namespace Quark.Runtime;
@@ -24,10 +25,12 @@ namespace Quark.Runtime;
 ///     <see cref="SiloRuntimeOptions.SchedulerMaxConcurrentActivations"/> concurrency guarantee: any
 ///     N distinct busy activations can still be serviced by N distinct workers concurrently,
 ///     regardless of which shard they land on.
-///     The idle-wake signal is sharded too: a per-worker <see cref="SemaphoreSlim"/> plus a lock-free
-///     idle-worker registry (<see cref="_idleWorkers"/>) target a single idle worker directly on each
+///     The idle-wake signal is sharded too: a per-worker <see cref="WorkerParkSignal"/> plus a lock-free
+///     idle-worker registry (<see cref="_idleBits"/>) target a single idle worker directly on each
 ///     shard's empty-&gt;non-empty transition, instead of every worker contending on one shared
 ///     semaphore -- see docs/superpowers/specs/2026-07-09-scheduler-wake-signal-sharding-design.md.
+///     <see cref="WorkerParkSignal"/> is an allocation-free reusable-value-task park primitive that
+///     replaced <c>SemaphoreSlim.WaitAsync(ct)</c>, whose cancelable slow path allocated ~200 B per park.
 ///
 ///     FIXED HAZARD (was: bounded-worker-pool reentrancy deadlock, found 2026-07-10 via the Realm
 ///     sample's TCP bot-driver benchmark; see GitHub issue #167) -- kept here for historical context,
@@ -92,31 +95,47 @@ internal sealed class ActivationScheduler : IActivationScheduler
     // the common path (PingPong, AstroSim, most workloads) pays nothing for this.
     private readonly SemaphoreSlim[]? _capacityGates;
 
-    // One idle-wake semaphore per worker (indexed by workerIndex, same value as the worker's home
-    // shard index -- shard count == worker count, unchanged). Released only for a worker whose index
-    // is popped off _idleWorkers, so a given semaphore normally has at most one waiter -- unlike a
-    // single shared semaphore, which every worker's WaitAsync/every enqueuer's Release contends on.
+    // One idle-wake signal per worker (indexed by workerIndex, same value as the worker's home shard
+    // index -- shard count == worker count, unchanged). Set() only for a worker whose index was claimed
+    // from _idleBits, so a given signal normally has at most one parked waiter -- unlike a single shared
+    // semaphore, which every worker's wait/every enqueuer's release would contend on.
     // See docs/superpowers/specs/2026-07-09-scheduler-wake-signal-sharding-design.md section 3.
-    private readonly SemaphoreSlim[] _workerSignals;
-
-    // Lock-free registry of worker indices that currently believe they're idle. An enqueuer's exact
-    // 0->1 transition (see _shardCounts) pops one entry (if any) and releases that worker's own
-    // semaphore -- a targeted wake instead of a broadcast. If the pop finds the stack empty, no
-    // release happens; a busy worker will still reach the transitioned shard on its own next full
-    // sweep after finishing its current drain, the same fallback the single-shared-semaphore design
-    // already relied on (a Release() against an already-positive semaphore doesn't queue a second
-    // waiter either).
     //
-    // A worker never removes its own entry: ConcurrentStack<T> has no remove-specific-value
-    // operation, only Pop (removes whatever is on top), so a "cancel my registration" Pop could
-    // remove a DIFFERENT worker's entry instead and strand it -- worse than the contention problem
-    // this design exists to fix. Stale entries (a worker listed idle while actually busy, because its
-    // own pre-park double-check found work without unregistering) are deliberately accepted: every
-    // worker still sweeps every shard unconditionally regardless of signal state, so no work is ever
-    // lost from a stale entry -- it only means a future transition's targeted release may land on a
-    // busy worker as a wasted credit, which self-corrects by making that worker's next park attempt a
-    // non-blocking no-op instead of a real park. See design spec section 4 for the full reasoning.
-    private readonly ConcurrentStack<int> _idleWorkers = new();
+    // WorkerParkSignal (a reusable IValueTaskSource async auto-reset event) replaces the earlier
+    // SemaphoreSlim(0, int.MaxValue): SemaphoreSlim.WaitAsync(ct)'s cancelable slow path allocated
+    // ~200 B per park (CancellationPromise<bool> + registration node + TaskNode), which dominated
+    // steady-state dispatch allocation whenever the workload ran in the "park regime" (round-trip longer
+    // than the spin-before-park window). WorkerParkSignal.WaitAsync() parks through a pooled value-task
+    // source, so a park allocates nothing. The token is dropped from the wait (DisposeAsync wakes every
+    // worker via Set() so each observes the cancelled token and exits, mirroring ArenaScheduler). A
+    // boolean auto-reset event is a sound replacement for the permit-counting semaphore because the wake
+    // is edge-triggered: after one wake a worker re-sweeps every shard until a sweep is empty, so a single
+    // signal drains arbitrarily many ready activations -- see the WorkerParkSignal remarks.
+    private readonly WorkerParkSignal[] _workerSignals;
+
+    // Lock-free registry of worker indices that currently believe they're idle, as a bitmask (bit i
+    // set == worker i registered idle). An enqueuer's exact 0->1 transition (see _shardCounts) claims
+    // one set bit (if any) via CAS and releases that worker's own semaphore -- a targeted wake instead
+    // of a broadcast. If no bit is set, no release happens; a busy worker will still reach the
+    // transitioned shard on its own next full sweep after finishing its current drain, the same
+    // fallback the single-shared-semaphore design already relied on (a Release() against an
+    // already-positive semaphore doesn't queue a second waiter either).
+    //
+    // Bitmask vs the earlier ConcurrentStack<int>: allocation-free (RegisterIdle is one Interlocked.Or,
+    // no per-idle node), and a worker's registration is a single idempotent bit rather than a stack
+    // that could accumulate duplicate entries for the same worker across park cycles -- one bit exactly
+    // matches "one worker can have at most one pending park," removing those spurious duplicate wakes.
+    // The Interlocked.Or (register) / CompareExchange (claim) are full barriers, so the wake-race
+    // happens-before argument is identical to the stack's: the register's barrier orders the worker's
+    // pre-park re-sweep after any enqueue that preceded it, and orders the bit visible to any enqueuer
+    // whose transition follows it. Stale bits (a worker listed idle while actually busy, because its
+    // pre-park double-check found work without clearing its bit) are still deliberately accepted:
+    // every worker sweeps every shard unconditionally regardless of signal state, so no work is lost --
+    // a stale bit only lets a future transition's targeted release land on a busy worker as a wasted
+    // credit, which self-corrects by making that worker's next park attempt a non-blocking no-op. Sized
+    // for worker count (== shard count); multiple 64-bit words cover machines with >64 cores.
+    // See docs/superpowers/specs/2026-07-09-scheduler-wake-signal-sharding-design.md section 4.
+    private readonly long[] _idleBits;
 
     private readonly CancellationTokenSource _cts = new();
     private readonly Task[] _workers;
@@ -165,9 +184,11 @@ internal sealed class ActivationScheduler : IActivationScheduler
                 _capacityGates[i] = new SemaphoreSlim(_queueCapacity, _queueCapacity);
         }
 
-        _workerSignals = new SemaphoreSlim[concurrency];
+        _workerSignals = new WorkerParkSignal[concurrency];
         for (int i = 0; i < concurrency; i++)
-            _workerSignals[i] = new SemaphoreSlim(0, int.MaxValue);
+            _workerSignals[i] = new WorkerParkSignal();
+
+        _idleBits = new long[(concurrency + 63) >> 6];
 
         _workers = new Task[concurrency];
         for (int i = 0; i < concurrency; i++)
@@ -188,6 +209,19 @@ internal sealed class ActivationScheduler : IActivationScheduler
 
     public async ValueTask ScheduleAsync(GrainActivation activation, CancellationToken cancellationToken = default)
     {
+        // Reject scheduling once shutdown has begun. After DisposeAsync cancels _cts the drain workers
+        // exit, so any activation enqueued past that point would never be drained -- a silent enqueue
+        // would hang its poster forever (GrainActivation.DisposeAsync posts its own OnDeactivate turn
+        // through here during teardown, and awaits the drain). Throwing instead lets that poster fall
+        // back to draining itself inline (GrainActivation.DrainDirectlyAndDeactivateAsync). This restores
+        // the contract the earlier Channel<GrainActivation>-based ready queue provided implicitly -- its
+        // ScheduleAsync threw ChannelClosedException once the channel completed on shutdown; the
+        // ConcurrentQueue that replaced it has no closed state, so the guard is now explicit. The check
+        // is a single volatile read on the hot path and is only ever true during shutdown.
+        if (_cts.IsCancellationRequested)
+            throw new ObjectDisposedException(nameof(ActivationScheduler),
+                "The activation scheduler is shutting down and can no longer accept new work.");
+
         if (!activation.TryMarkScheduled())
             return;
 
@@ -224,22 +258,69 @@ internal sealed class ActivationScheduler : IActivationScheduler
         ConcurrentQueue<GrainActivation> shard = _shards[shardIndex];
         shard.Enqueue(activation);
         int depth = Interlocked.Increment(ref _shardCounts[shardIndex]);
-        if (depth == 1 && _idleWorkers.TryPop(out int idleWorker))
-            _workerSignals[idleWorker].Release();
+        if (depth == 1 && TryClaimIdleWorker(out int idleWorker))
+            _workerSignals[idleWorker].Set();
 
         QuarkInstruments.SchedulerReadyQueueDepth.Add(1);
         _diagnostics.OnSchedulerReadyQueueDepthChanged(
             new SchedulerReadyQueueDepthChangedEvent(depth, 1));
     }
 
+    /// <summary>
+    ///     Marks worker <paramref name="workerIndex"/> as idle in <see cref="_idleBits"/>. Idempotent:
+    ///     setting an already-set bit is a no-op, so a worker that registers idle across successive park
+    ///     cycles occupies exactly one bit. The <see cref="Interlocked.Or(ref long, long)"/> is a full
+    ///     barrier, ordering the worker's subsequent pre-park re-sweep after this registration.
+    /// </summary>
+    private void RegisterIdle(int workerIndex)
+        => Interlocked.Or(ref _idleBits[workerIndex >> 6], 1L << (workerIndex & 63));
+
+    /// <summary>
+    ///     Atomically claims and clears one set bit from <see cref="_idleBits"/> (any idle worker),
+    ///     returning its index. Returns <see langword="false"/> when no worker is registered idle. The
+    ///     per-word CAS guarantees two concurrent enqueuers never both claim the same worker; a lost CAS
+    ///     retries against the freshly observed word. Scans words low-to-high, lowest set bit first.
+    /// </summary>
+    private bool TryClaimIdleWorker(out int workerIndex)
+    {
+        for (int word = 0; word < _idleBits.Length; word++)
+        {
+            long observed = Volatile.Read(ref _idleBits[word]);
+            while (observed != 0)
+            {
+                int bit = BitOperations.TrailingZeroCount(observed);
+                long cleared = observed & ~(1L << bit);
+                long prior = Interlocked.CompareExchange(ref _idleBits[word], cleared, observed);
+                if (prior == observed)
+                {
+                    workerIndex = (word << 6) + bit;
+                    return true;
+                }
+
+                observed = prior; // Another thread mutated this word; retry with its current value.
+            }
+        }
+
+        workerIndex = -1;
+        return false;
+    }
+
     public async ValueTask DisposeAsync()
     {
         await _cts.CancelAsync().ConfigureAwait(false);
 
+        // Token-free park: a worker blocked in WorkerParkSignal.WaitAsync() cannot observe the cancelled
+        // token on its own (there is no token in the wait), so wake every worker. Each then re-checks
+        // ct.IsCancellationRequested after the park and exits its loop. Set() on an unparked worker is
+        // stored and consumed as a synchronous no-op on its next park attempt, before that re-check.
+        // Mirrors ArenaScheduler.DisposeAsync's "release every signal on shutdown."
+        foreach (WorkerParkSignal signal in _workerSignals)
+            signal.Set();
+
         // Snapshot live overflow workers after requesting cancellation -- CheckForStallAndSpawnOverflow
         // checks _cts.IsCancellationRequested before spawning a new one, so this is complete modulo a
         // narrow best-effort race (matches this class's existing tolerance for small races elsewhere,
-        // e.g. stale _idleWorkers entries).
+        // e.g. stale _idleBits entries).
         Task allWorkers = Task.WhenAll(_workers.Append(_stallWatchdog).Concat(_overflowWorkers.Keys));
 
         // Surface a stuck shutdown instead of just hanging silently — a hung drain worker
@@ -266,8 +347,8 @@ internal sealed class ActivationScheduler : IActivationScheduler
             // Worker cancellation is expected.
         }
         _cts.Dispose();
-        foreach (SemaphoreSlim workerSignal in _workerSignals)
-            workerSignal.Dispose();
+        // WorkerParkSignal holds no unmanaged/disposable resource (a reusable value-task source), so
+        // unlike the SemaphoreSlim it replaced there is nothing to dispose here.
         if (_capacityGates is not null)
         {
             foreach (SemaphoreSlim gate in _capacityGates)
@@ -321,38 +402,59 @@ internal sealed class ActivationScheduler : IActivationScheduler
                 if (ct.IsCancellationRequested)
                     return;
 
-                // Register as idle, then re-sweep once before parking (double-check). Any
-                // transition that landed before this Push is visible to this re-sweep -- the
-                // enqueuer's Interlocked.Increment happens-before any TryPop it performs, and this
-                // Push happens-before the re-sweep's reads. Any transition landing after this Push
-                // is visible to the enqueuer's TryPop, which will target this worker's own
-                // semaphore directly, and the subsequent WaitAsync below consumes that credit
-                // without blocking. There is no gap between "registered idle" and "unreachable by
-                // a wake."
-                _idleWorkers.Push(workerIndex);
-
-                activation = TryDequeueAny(ref cursor);
+                // Bounded, UNREGISTERED spin before touching the idle registry or parking. Under a
+                // hot workload the next item lands within microseconds, so re-checking the shards a
+                // few times catches it and skips both the RegisterIdle bit-set and
+                // SemaphoreSlim.WaitAsync(ct)'s slow path (an AsyncStateMachineBox + CancellationPromise
+                // per park) -- together these dominated steady-state dispatch allocation. This spin
+                // registers nothing, so it is pure optimism in front of the original race-guarded park
+                // below; it stops before SpinWait would yield the thread, so a genuinely idle system
+                // falls through and parks promptly instead of busy-waiting.
+                var spin = new SpinWait();
+                while (activation is null && !spin.NextSpinWillYield)
+                {
+                    spin.SpinOnce();
+                    activation = TryDequeueAny(ref cursor);
+                }
 
                 if (activation is null)
                 {
-                    // This worker's idle-stack entry is intentionally left in place here -- see
-                    // the class-level remarks on _idleWorkers for why a self-removal Pop would be
-                    // unsafe. It stays until an enqueuer's TryPop consumes it.
-                    try
-                    {
-                        await _workerSignals[workerIndex].WaitAsync(ct).ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException)
-                    {
+                    if (ct.IsCancellationRequested)
                         return;
+
+                    // Register as idle, then re-sweep once before parking (double-check). Any
+                    // transition that landed before this RegisterIdle is visible to this re-sweep --
+                    // the enqueuer's Interlocked.Increment happens-before any TryClaimIdleWorker it
+                    // performs, and this bit-set happens-before the re-sweep's reads. Any transition
+                    // landing after this bit-set is visible to the enqueuer's TryClaimIdleWorker, which
+                    // will target this worker's own semaphore directly, and the subsequent WaitAsync
+                    // below consumes that credit without blocking. There is no gap between "registered
+                    // idle" and "unreachable by a wake."
+                    RegisterIdle(workerIndex);
+
+                    activation = TryDequeueAny(ref cursor);
+
+                    if (activation is null)
+                    {
+                        // This worker's idle bit is intentionally left set here -- see the class-level
+                        // remarks on _idleBits for why stale bits are safe. It stays set until an
+                        // enqueuer's TryClaimIdleWorker consumes it.
+                        //
+                        // WorkerParkSignal.WaitAsync() is token-free (allocation-free park); DisposeAsync
+                        // Set()s every worker on cancellation, so a parked worker wakes and observes the
+                        // token here. A Set() that arrived before this park (an enqueuer targeting this
+                        // worker, or Dispose) is stored and consumed synchronously without blocking.
+                        await _workerSignals[workerIndex].WaitAsync().ConfigureAwait(false);
+
+                        if (ct.IsCancellationRequested)
+                            return;
+
+                        continue;
                     }
 
-                    continue;
+                    // The double-check found work. The idle bit set above is deliberately NOT cleared
+                    // -- see the class-level remarks on _idleBits. Fall through and process normally.
                 }
-
-                // The double-check found work. The idle-stack entry pushed above is deliberately
-                // NOT removed -- see the class-level remarks on _idleWorkers. Fall through and
-                // process this activation normally.
             }
 
             await DrainDispatchedActivationAsync(activation, cursor, ct).ConfigureAwait(false);
@@ -447,7 +549,7 @@ internal sealed class ActivationScheduler : IActivationScheduler
     ///     Transient rescue capacity spun up by <see cref="RunStallWatchdogAsync"/> when the ready
     ///     queue shows no progress for too long -- see the FIX section of the class remarks. Sweeps
     ///     shards using the same <see cref="TryDequeueAny"/> logic as a primary worker, but unlike a
-    ///     primary worker it never registers on <see cref="_idleWorkers"/> or parks: after a short run
+    ///     primary worker it never registers on <see cref="_idleBits"/> or parks: after a short run
     ///     of consecutive empty sweeps it just retires, since overflow workers are meant to drain a
     ///     backlog and disappear, not join the steady-state pool.
     /// </summary>

--- a/src/Quark.Runtime/GrainActivation.cs
+++ b/src/Quark.Runtime/GrainActivation.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Quark.Core.Abstractions.Grains;
 using Quark.Core.Abstractions.Hosting;
+using Quark.Core.Abstractions.Scheduling;
 using Quark.Core.Abstractions.Timers;
 using Quark.Diagnostics.Abstractions;
 using Quark.Persistence.Abstractions;
@@ -59,9 +60,27 @@ public sealed class GrainActivation : IAsyncDisposable
     // Probes never run scheduler-driven drains — Deactivate() must not schedule real work for them.
     private readonly bool _isProbe;
 
-    private readonly Channel<IMailboxWorkItem> _queue;
+    // Message-priority mailbox: one FIFO lane per MessagePriority value, indexed by (int)priority.
+    // The drain reads the highest-priority non-empty lane first, so a higher-priority message jumps
+    // ahead of lower-priority ones already queued for this grain (strict priority, FIFO within a lane).
+    // Each lane reuses the same bounded/unbounded Channel machinery the single mailbox used, so a
+    // bounded mailbox now bounds each lane independently (per-lane capacity).
+    private const int LaneCount = 4; // must equal the number of MessagePriority values
+    private readonly Channel<IMailboxWorkItem>[] _lanes;
     private readonly int _mailboxCapacity;
     private readonly MailboxFullMode _mailboxFullMode;
+
+    // Part A (activation-scoped behaviors): true when this grain type opted into IActivationBehavior.
+    // A single behavior instance + a single IServiceScope live for the whole activation — constructed
+    // once (EnsureActivationBehavior), reused for every call, and disposed on deactivation — instead of
+    // the per-call scope+resolution the default IGrainBehavior path pays. Only enabled for non-reentrant
+    // grains (LocalGrainCallInvoker.CreateActivationAsync throws for reentrant + IActivationBehavior),
+    // so the per-turn call-context refresh in BindActivationBehavior runs on a serial drain and is safe.
+    private readonly bool _isActivationScoped;
+    private IServiceScope? _activationScope;
+    private IServiceProvider? _activationConstructionServices;
+    private IGrainBehavior? _activationBehavior;
+    private ICallContextSetter? _activationCallContextSetter;
 
     internal GrainActivation(
         GrainId grainId,
@@ -72,7 +91,8 @@ public sealed class GrainActivation : IAsyncDisposable
         IActivationScheduler scheduler,
         IQuarkDiagnosticListener? diagnostics = null,
         int mailboxCapacity = 0,
-        MailboxFullMode mailboxFullMode = MailboxFullMode.Wait)
+        MailboxFullMode mailboxFullMode = MailboxFullMode.Wait,
+        bool isActivationScoped = false)
     {
         GrainId = grainId;
         GrainType = grainType;
@@ -82,8 +102,9 @@ public sealed class GrainActivation : IAsyncDisposable
         _diagnostics = diagnostics ?? NullDiagnosticListener.Instance;
         _mailboxCapacity = mailboxCapacity;
         _mailboxFullMode = mailboxFullMode;
-        _queue = CreateQueue(mailboxCapacity);
+        _lanes = CreateLanes(mailboxCapacity);
         _scheduler = scheduler;
+        _isActivationScoped = isActivationScoped;
         _lastAccessedTicks = DateTimeOffset.UtcNow.UtcTicks;
     }
 
@@ -102,6 +123,49 @@ public sealed class GrainActivation : IAsyncDisposable
                     FullMode = BoundedChannelFullMode.Wait,
                 });
 
+    // One Channel per priority lane. A bounded mailbox bounds each lane at `capacity` independently;
+    // this keeps the proven per-Channel enqueue/backpressure logic unchanged and stops a flood of one
+    // priority from consuming another lane's capacity.
+    private static Channel<IMailboxWorkItem>[] CreateLanes(int capacity)
+    {
+        var lanes = new Channel<IMailboxWorkItem>[LaneCount];
+        for (int i = 0; i < LaneCount; i++)
+            lanes[i] = CreateQueue(capacity);
+        return lanes;
+    }
+
+    // Reads the next work item, highest-priority lane first (Urgent → Low), FIFO within a lane.
+    private bool TryReadNext([System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out IMailboxWorkItem item)
+    {
+        for (int lane = LaneCount - 1; lane >= 0; lane--)
+        {
+            if (_lanes[lane].Reader.TryRead(out item))
+                return true;
+        }
+
+        item = null;
+        return false;
+    }
+
+    // True if any lane still holds an undispatched work item.
+    private bool MailboxHasWork()
+    {
+        for (int lane = 0; lane < LaneCount; lane++)
+        {
+            if (_lanes[lane].Reader.TryPeek(out _))
+                return true;
+        }
+
+        return false;
+    }
+
+    // Completes every lane's writer (mailbox shutdown).
+    private void CompleteLanes()
+    {
+        for (int lane = 0; lane < LaneCount; lane++)
+            _lanes[lane].Writer.TryComplete();
+    }
+
     // Probe constructor — no processing loop, used only by BehaviorStartupValidator.
     private GrainActivation(GrainId grainId, GrainType grainType, IServiceProvider root)
     {
@@ -110,7 +174,7 @@ public sealed class GrainActivation : IAsyncDisposable
         _root = root;
         _logger = NullLogger<GrainActivation>.Instance;
         _diagnostics = NullDiagnosticListener.Instance;
-        _queue = CreateQueue(0);
+        _lanes = CreateLanes(0);
         _scheduler = SimpleActivationScheduler.Instance;
         _status = GrainActivationStatus.Active;
         _lastAccessedTicks = 0;
@@ -130,6 +194,13 @@ public sealed class GrainActivation : IAsyncDisposable
 
     /// <summary>The grain type key used to look up the behavior class.</summary>
     public GrainType GrainType { get; }
+
+    /// <summary>
+    ///     True when this grain type opted into <c>IActivationBehavior</c> (per-activation lifetime).
+    ///     The dispatch path uses <see cref="BindActivationBehavior"/> — one cached instance + scope —
+    ///     instead of constructing a fresh behavior in a per-call scope.
+    /// </summary>
+    internal bool IsActivationScoped => _isActivationScoped;
 
     /// <summary>Current lifecycle status of this activation.</summary>
     public GrainActivationStatus ActivationStatus => _status;
@@ -163,7 +234,7 @@ public sealed class GrainActivation : IAsyncDisposable
 
     // Phase 2: scheduler polls this after a drain to decide whether to reschedule.
     internal bool HasPendingWork
-        => _queue.Reader.TryPeek(out _) || _status == GrainActivationStatus.Deactivating;
+        => MailboxHasWork() || _status == GrainActivationStatus.Deactivating;
 
     /// <summary>
     ///     Returns or creates the <see cref="StateHolder{TState}" /> for the given state type.
@@ -389,7 +460,7 @@ public sealed class GrainActivation : IAsyncDisposable
         }
 
         await _cts.CancelAsync().ConfigureAwait(false);
-        _queue.Writer.TryComplete();
+        CompleteLanes();
 
         // Phase 3: await the explicit completion signal set by RunDeactivationAsync, replacing
         // the old `await _processingLoop` pattern. Handles the case where Deactivate() was
@@ -472,7 +543,7 @@ public sealed class GrainActivation : IAsyncDisposable
         int count = 0;
 
         while (!ct.IsCancellationRequested && count < maxItems
-               && _queue.Reader.TryRead(out IMailboxWorkItem? item))
+               && TryReadNext(out IMailboxWorkItem? item))
         {
             Interlocked.Decrement(ref _pendingWorkCount);
             Interlocked.Exchange(ref _workItemStartedAt, Stopwatch.GetTimestamp());
@@ -492,7 +563,7 @@ public sealed class GrainActivation : IAsyncDisposable
             count++;
         }
 
-        bool hasMore = _queue.Reader.TryPeek(out _);
+        bool hasMore = MailboxHasWork();
 
         // Livelock detection: a drain pass that processes nothing while work remains queued means
         // this activation is being rescheduled without ever making progress (e.g. its own
@@ -534,7 +605,7 @@ public sealed class GrainActivation : IAsyncDisposable
         Interlocked.Exchange(ref _scheduled, 0);
         // Full memory barrier via Interlocked ensures items written by concurrent PostAsync calls
         // are visible before we peek the channel.
-        return _queue.Reader.TryPeek(out _) || _status == GrainActivationStatus.Deactivating;
+        return MailboxHasWork() || _status == GrainActivationStatus.Deactivating;
     }
 
     /// <summary>
@@ -578,7 +649,16 @@ public sealed class GrainActivation : IAsyncDisposable
     ///     inline — see that enum value's documentation for the scheduler-invisibility tradeoff.
     ///     Phase 3: rejects new work when the grain is already Deactivating or Inactive.
     /// </summary>
-    public ValueTask PostAsync(Func<ValueTask> workItem)
+    public ValueTask PostAsync(Func<ValueTask> workItem) => PostAsync(workItem, MessagePriority.Normal);
+
+    /// <summary>
+    ///     Posts a unit of work to this grain's mailbox at the given <paramref name="priority"/> and
+    ///     awaits its completion. A higher-priority post is drained ahead of lower-priority work already
+    ///     queued for this grain, but never interrupts the turn currently executing (non-preemptive);
+    ///     posts at the same priority preserve arrival order (FIFO). Reentrant activations run inline and
+    ///     ignore priority — see <see cref="ReentrantSchedulingMode.Immediate"/>.
+    /// </summary>
+    public ValueTask PostAsync(Func<ValueTask> workItem, MessagePriority priority)
     {
         if (_reentrantMode == ReentrantSchedulingMode.Immediate)
         {
@@ -595,7 +675,7 @@ public sealed class GrainActivation : IAsyncDisposable
                 new OperationCanceledException($"Grain {GrainId} is {status.ToString().ToLowerInvariant()}."));
         }
 
-        return PostCoreAsync(workItem);
+        return PostCoreAsync(workItem, priority);
     }
 
     /// <summary>
@@ -620,7 +700,7 @@ public sealed class GrainActivation : IAsyncDisposable
                 new OperationCanceledException($"Grain {GrainId} is {status.ToString().ToLowerInvariant()}."));
         }
 
-        return PostCoreAsync(state, workItem);
+        return PostCoreAsync(state, workItem, MessagePriority.Normal);
     }
 
     /// <summary>
@@ -644,10 +724,11 @@ public sealed class GrainActivation : IAsyncDisposable
                 new OperationCanceledException($"Grain {GrainId} is {status.ToString().ToLowerInvariant()}."));
         }
 
-        return PostCoreAsync(state, workItem);
+        return PostCoreAsync(state, workItem, MessagePriority.Normal);
     }
 
-    private async ValueTask PostCoreAsync<TState>(TState state, Func<TState, ValueTask> workItem)
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+    private async ValueTask PostCoreAsync<TState>(TState state, Func<TState, ValueTask> workItem, MessagePriority priority)
     {
         Interlocked.Exchange(ref _lastAccessedTicks, DateTimeOffset.UtcNow.UtcTicks);
         int depth = Interlocked.Increment(ref _pendingWorkCount);
@@ -658,7 +739,7 @@ public sealed class GrainActivation : IAsyncDisposable
 
         if (_mailboxFullMode == MailboxFullMode.RejectWhenFull && _mailboxCapacity > 0)
         {
-            if (!_queue.Writer.TryWrite(item))
+            if (!_lanes[(int)priority].Writer.TryWrite(item))
             {
                 Interlocked.Decrement(ref _pendingWorkCount);
                 item.ReturnOnEnqueueFailure();
@@ -669,7 +750,7 @@ public sealed class GrainActivation : IAsyncDisposable
         {
             try
             {
-                await _queue.Writer.WriteAsync(item, _cts.Token).ConfigureAwait(false);
+                await _lanes[(int)priority].Writer.WriteAsync(item, _cts.Token).ConfigureAwait(false);
             }
             catch
             {
@@ -682,7 +763,8 @@ public sealed class GrainActivation : IAsyncDisposable
         await item.WaitAsync().ConfigureAwait(false);
     }
 
-    private async ValueTask<TResult> PostCoreAsync<TState, TResult>(TState state, Func<TState, ValueTask<TResult>> workItem)
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+    private async ValueTask<TResult> PostCoreAsync<TState, TResult>(TState state, Func<TState, ValueTask<TResult>> workItem, MessagePriority priority)
     {
         Interlocked.Exchange(ref _lastAccessedTicks, DateTimeOffset.UtcNow.UtcTicks);
         int depth = Interlocked.Increment(ref _pendingWorkCount);
@@ -693,7 +775,7 @@ public sealed class GrainActivation : IAsyncDisposable
 
         if (_mailboxFullMode == MailboxFullMode.RejectWhenFull && _mailboxCapacity > 0)
         {
-            if (!_queue.Writer.TryWrite(item))
+            if (!_lanes[(int)priority].Writer.TryWrite(item))
             {
                 Interlocked.Decrement(ref _pendingWorkCount);
                 item.ReturnOnEnqueueFailure();
@@ -704,7 +786,7 @@ public sealed class GrainActivation : IAsyncDisposable
         {
             try
             {
-                await _queue.Writer.WriteAsync(item, _cts.Token).ConfigureAwait(false);
+                await _lanes[(int)priority].Writer.WriteAsync(item, _cts.Token).ConfigureAwait(false);
             }
             catch
             {
@@ -717,7 +799,8 @@ public sealed class GrainActivation : IAsyncDisposable
         return await item.WaitAsync().ConfigureAwait(false);
     }
 
-    private async ValueTask PostCoreAsync(Func<ValueTask> workItem)
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+    private async ValueTask PostCoreAsync(Func<ValueTask> workItem, MessagePriority priority)
     {
         Interlocked.Exchange(ref _lastAccessedTicks, DateTimeOffset.UtcNow.UtcTicks);
         int depth = Interlocked.Increment(ref _pendingWorkCount);
@@ -731,7 +814,7 @@ public sealed class GrainActivation : IAsyncDisposable
         if (_mailboxFullMode == MailboxFullMode.RejectWhenFull && _mailboxCapacity > 0)
         {
             // Fail fast when the bounded mailbox is full rather than waiting for space.
-            if (!_queue.Writer.TryWrite(item))
+            if (!_lanes[(int)priority].Writer.TryWrite(item))
             {
                 Interlocked.Decrement(ref _pendingWorkCount);
                 item.ReturnOnEnqueueFailure();
@@ -742,7 +825,7 @@ public sealed class GrainActivation : IAsyncDisposable
         {
             try
             {
-                await _queue.Writer.WriteAsync(item, _cts.Token).ConfigureAwait(false);
+                await _lanes[(int)priority].Writer.WriteAsync(item, _cts.Token).ConfigureAwait(false);
             }
             catch
             {
@@ -784,7 +867,8 @@ public sealed class GrainActivation : IAsyncDisposable
         }
 
         await DisposeManagedHoldersAsync().ConfigureAwait(false);
-        _queue.Writer.TryComplete();
+        await DisposeActivationScopeAsync().ConfigureAwait(false);
+        CompleteLanes();
 
         long activatedAt = Interlocked.Read(ref _activatedAtTicks);
         TimeSpan lifetime = activatedAt > 0 ? Stopwatch.GetElapsedTime(activatedAt) : TimeSpan.Zero;
@@ -837,6 +921,38 @@ public sealed class GrainActivation : IAsyncDisposable
         }
     }
 
+    // Disposes the activation-lifetime scope (and everything resolved into it, including the cached
+    // behavior) after OnDeactivateAsync + managed-holder cleanup have run. No-op for the per-call model.
+    private async ValueTask DisposeActivationScopeAsync()
+    {
+        IServiceScope? scope = _activationScope;
+        if (scope is null)
+        {
+            return;
+        }
+
+        _activationBehavior = null;
+        _activationCallContextSetter = null;
+        _activationConstructionServices = null;
+        _activationScope = null;
+
+        try
+        {
+            if (scope is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                scope.Dispose();
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "Error disposing activation scope for {GrainId}", GrainId);
+        }
+    }
+
     private async Task DisposeManagedHoldersAsync()
     {
         foreach (object obj in _memoryBag.Values)
@@ -861,6 +977,18 @@ public sealed class GrainActivation : IAsyncDisposable
         Func<IActivationLifecycle, Task> hook,
         CancellationToken cancellationToken = default)
     {
+        // Activation-scoped: run the hook on the single cached instance so a stateful behavior's
+        // OnDeactivateAsync observes the activation's final field state.
+        if (_isActivationScoped)
+        {
+            if (EnsureActivationBehavior() is IActivationLifecycle lifecycle)
+            {
+                await hook(lifecycle).ConfigureAwait(false);
+            }
+
+            return;
+        }
+
         (IServiceScope scope, IServiceProvider constructionServices) = GrainScopeBinder.CreateCallScope(_root, this);
         using (scope)
         {
@@ -872,6 +1000,46 @@ public sealed class GrainActivation : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    ///     Constructs the single per-activation behavior instance on first use (creating the
+    ///     activation-lifetime <see cref="IServiceScope"/>), binding the constant-for-the-activation
+    ///     shell reference and grain id once. Idempotent; only valid on <c>IActivationBehavior</c> grains.
+    ///     Called only on the serial activation/drain/deactivation path — not thread-safe by design,
+    ///     which is why reentrant grains are excluded (they would call it under concurrent turns).
+    /// </summary>
+    private IGrainBehavior EnsureActivationBehavior()
+    {
+        if (_activationBehavior is not null)
+        {
+            return _activationBehavior;
+        }
+
+        (IServiceScope scope, IServiceProvider constructionServices) = GrainScopeBinder.CreateCallScope(_root, this);
+        _activationScope = scope;
+        _activationConstructionServices = constructionServices;
+
+        ((ActivationShellAccessor)scope.ServiceProvider.GetRequiredService<IActivationShellAccessor>()).Shell = this;
+        _activationCallContextSetter = scope.ServiceProvider.GetRequiredService<ICallContextSetter>();
+        _activationCallContextSetter.Set(GrainId); // the grain's own id — constant for the activation
+
+        _activationBehavior = scope.ServiceProvider
+            .GetRequiredService<IBehaviorResolver>()
+            .Resolve(GrainType, constructionServices);
+        return _activationBehavior;
+    }
+
+    /// <summary>
+    ///     Returns the cached per-activation behavior instance for a call, refreshing the per-call
+    ///     idempotency key. Safe to mutate the shared call context here because activation-scoped grains
+    ///     are non-reentrant, so their turns drain serially. Invoked from the dispatch fast path.
+    /// </summary>
+    internal IGrainBehavior BindActivationBehavior()
+    {
+        IGrainBehavior behavior = EnsureActivationBehavior();
+        _activationCallContextSetter!.SetIdempotencyKey(QuarkRequestContext.IdempotencyKey);
+        return behavior;
+    }
+
     // Runs the full activation sequence:
     // 1. Bind shell accessor + call context, using the Quark-only scope for opted-in grain types
     //    (see GrainScopeBinder.CreateCallScope) or the flat scope otherwise.
@@ -880,6 +1048,20 @@ public sealed class GrainActivation : IAsyncDisposable
     // 4. Call OnActivateAsync if the behavior implements IActivationLifecycle.
     internal async Task RunActivationAsync(CancellationToken ct)
     {
+        // Activation-scoped: construct the single instance + scope now (first use) and keep them for the
+        // activation's lifetime. Eager init + OnActivateAsync run against that same cached instance.
+        if (_isActivationScoped)
+        {
+            IGrainBehavior behavior = EnsureActivationBehavior();
+            await RunEagerInitAsync(_activationConstructionServices!, ct).ConfigureAwait(false);
+            if (behavior is IActivationLifecycle lifecycle)
+            {
+                await lifecycle.OnActivateAsync(ct).ConfigureAwait(false);
+            }
+
+            return;
+        }
+
         (IServiceScope scope, IServiceProvider constructionServices) = GrainScopeBinder.CreateCallScope(_root, this);
         using (scope)
         {

--- a/src/Quark.Runtime/GrainActivationTable.cs
+++ b/src/Quark.Runtime/GrainActivationTable.cs
@@ -89,6 +89,33 @@ public sealed class GrainActivationTable : IAsyncDisposable
     }
 
     /// <summary>
+    ///     State-passing overload of <see cref="GetOrCreateAsync(GrainId, Func{ValueTask{GrainActivation}})"/>
+    ///     that avoids the per-call factory-closure allocation on the hot (cache-hit) path — the caller
+    ///     passes a <c>static</c> delegate plus a struct <paramref name="state"/> instead of a lambda that
+    ///     captures its arguments. Dedup semantics are identical: the same <see cref="Lazy{T}"/> guarantees
+    ///     the factory runs at most once per grain. The closure over <paramref name="state"/>/
+    ///     <paramref name="factory"/> that the <see cref="Lazy{T}"/> needs is created only on a cache miss.
+    /// </summary>
+    public ValueTask<GrainActivation> GetOrCreateAsync<TState>(
+        GrainId grainId, TState state, Func<TState, ValueTask<GrainActivation>> factory)
+    {
+        if (_activations.TryGetValue(grainId, out Lazy<Task<GrainActivation>>? existing))
+        {
+            return new ValueTask<GrainActivation>(existing.Value);
+        }
+
+        if (_maxActivations > 0 && _activations.Count >= _maxActivations)
+        {
+            throw new GrainActivationLimitExceededException(grainId, _maxActivations);
+        }
+
+        Lazy<Task<GrainActivation>> lazy = _activations.GetOrAdd(grainId,
+            static (_, arg) => new Lazy<Task<GrainActivation>>(() => arg.factory(arg.state).AsTask()),
+            (state, factory));
+        return new ValueTask<GrainActivation>(lazy.Value);
+    }
+
+    /// <summary>
     ///     Removes the activation entry for <paramref name="grainId" /> if it is currently
     ///     faulted.  Called by the invoker after a failed activation so that the next call
     ///     can attempt a fresh activation.

--- a/src/Quark.Runtime/LocalGrainCallInvoker.cs
+++ b/src/Quark.Runtime/LocalGrainCallInvoker.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -82,6 +83,7 @@ public sealed class LocalGrainCallInvoker : IGrainCallInvoker
     }
 
     /// <inheritdoc />
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
     public async ValueTask<TResult> InvokeAsync<TInvokable, TResult>(
         GrainId grainId,
         TInvokable invokable,
@@ -135,6 +137,18 @@ public sealed class LocalGrainCallInvoker : IGrainCallInvoker
                 new InvokeCallState<TInvokable, TResult>(_services, activation, cancellationToken, invokable, _copierProvider),
                 static async s =>
                 {
+                    // Part A fast path: reuse the cached per-activation instance (no scope, no resolution).
+                    if (s.Activation.IsActivationScoped)
+                    {
+                        IGrainBehavior activationBehavior = s.Activation.BindActivationBehavior();
+                        TResult ar = await s.Invokable.Invoke(activationBehavior).ConfigureAwait(false);
+                        if (s.CopierProvider?.TryGetCopier<TResult>() is { } activationCopier)
+                        {
+                            ar = activationCopier.DeepCopy(ar, new CopyContext());
+                        }
+                        return ar;
+                    }
+
                     (IServiceScope scope, IServiceProvider sp) = GrainScopeBinder.CreateCallScope(s.Services, s.Activation);
                     using (scope)
                     {
@@ -169,6 +183,7 @@ public sealed class LocalGrainCallInvoker : IGrainCallInvoker
     }
 
     /// <inheritdoc />
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
     public async ValueTask InvokeVoidAsync<TInvokable>(
         GrainId grainId,
         TInvokable invokable,
@@ -223,6 +238,14 @@ public sealed class LocalGrainCallInvoker : IGrainCallInvoker
                 new InvokeVoidState<TInvokable>(_services, activation, cancellationToken, invokable),
                 static async s =>
                 {
+                    // Part A fast path: reuse the cached per-activation instance (no scope, no resolution).
+                    if (s.Activation.IsActivationScoped)
+                    {
+                        IGrainBehavior activationBehavior = s.Activation.BindActivationBehavior();
+                        await s.Invokable.Invoke(activationBehavior).ConfigureAwait(false);
+                        return;
+                    }
+
                     (IServiceScope scope, IServiceProvider sp) = GrainScopeBinder.CreateCallScope(s.Services, s.Activation);
                     using (scope)
                     {
@@ -359,7 +382,11 @@ public sealed class LocalGrainCallInvoker : IGrainCallInvoker
     {
         try
         {
-            return await _activationTable.GetOrCreateAsync(grainId, () => CreateActivationAsync(grainId, ct))
+            // State-passing overload + static delegate: no per-call factory closure on the cache-hit
+            // path (the common case). All captured data travels in the struct tuple.
+            return await _activationTable.GetOrCreateAsync(
+                    grainId, (self: this, grainId, ct),
+                    static s => s.self.CreateActivationAsync(s.grainId, s.ct))
                 .ConfigureAwait(false);
         }
         catch
@@ -421,8 +448,23 @@ public sealed class LocalGrainCallInvoker : IGrainCallInvoker
         long activationStart = Stopwatch.GetTimestamp();
 
         bool isReentrant = behaviorType.IsDefined(typeof(ReentrantAttribute), inherit: true);
+
+        // Part A: per-activation behavior lifetime (IActivationBehavior). One-time interface check per
+        // activation (not per call) — AOT-safe (no dynamic code). Slice (d) will move this to a
+        // generator-emitted flag. Reentrant + activation-scoped is not yet supported (a shared instance
+        // under concurrent turns needs a per-turn call-context strategy) — fail loud rather than run
+        // with silently wrong call-context isolation.
+        bool isActivationScoped = typeof(IActivationBehavior).IsAssignableFrom(behaviorType);
+        if (isActivationScoped && isReentrant)
+        {
+            throw new NotSupportedException(
+                $"Grain behavior '{behaviorType.Name}' implements IActivationBehavior and is [Reentrant]. " +
+                "Per-activation behaviors are not yet supported on reentrant grains. " +
+                "Remove [Reentrant], or drop IActivationBehavior to use the default per-call model.");
+        }
+
         var activation = new GrainActivation(grainId, grainId.Type, isReentrant, _services, _activationLogger,
-            _scheduler, _diagnostics, _mailboxCapacity, _mailboxFullMode);
+            _scheduler, _diagnostics, _mailboxCapacity, _mailboxFullMode, isActivationScoped);
 
         // Resolve behavior (ctor registers eager factories), init eager holders with the activation
         // scope's SP, then call OnActivateAsync if IActivationLifecycle. Single scope — no double construction.

--- a/src/Quark.Runtime/RuntimeServiceCollectionExtensions.cs
+++ b/src/Quark.Runtime/RuntimeServiceCollectionExtensions.cs
@@ -88,10 +88,20 @@ public static class RuntimeServiceCollectionExtensions
         // SimpleActivationScheduler (unbounded Task.Run per activation, no concurrency cap or other
         // QoS knobs) remains available for callers that want it explicitly — e.g. the
         // `--bare` PingPong benchmark mode.
-        services.TryAddSingleton<IActivationScheduler>(sp => new ActivationScheduler(
-            sp.GetRequiredService<IOptions<SiloRuntimeOptions>>().Value,
-            sp.GetService<IQuarkDiagnosticListener>(),
-            sp.GetService<IOptions<DiagnosticOptions>>()?.Value));
+        // SchedulerKind.ArenaV2 opts into the next-generation ArenaScheduler (dedicated worker threads,
+        // per-worker work-stealing deques — docs/superpowers/specs/2026-07-12-next-gen-scheduler-design.md).
+        // The default stays ActivationScheduler until the arena scheduler reaches parity across the full
+        // benchmark suite and its later phases (cooperative async resume, rescue) land.
+        services.TryAddSingleton<IActivationScheduler>(sp =>
+        {
+            SiloRuntimeOptions runtimeOptions = sp.GetRequiredService<IOptions<SiloRuntimeOptions>>().Value;
+            IQuarkDiagnosticListener? listener = sp.GetService<IQuarkDiagnosticListener>();
+            DiagnosticOptions? diagOptions = sp.GetService<IOptions<DiagnosticOptions>>()?.Value;
+
+            return runtimeOptions.SchedulerKind == SchedulerKind.ArenaV2
+                ? new ArenaScheduler(runtimeOptions, listener, diagOptions)
+                : new ActivationScheduler(runtimeOptions, listener, diagOptions);
+        });
 
         // Stateless-worker pool router (singleton; pool dictionaries keyed by logical grain id)
         services.TryAddSingleton<StatelessWorkerRouter>();

--- a/src/Quark.Runtime/SchedulerKind.cs
+++ b/src/Quark.Runtime/SchedulerKind.cs
@@ -1,0 +1,22 @@
+namespace Quark.Runtime;
+
+/// <summary>
+///     Selects which activation scheduler implementation the silo runtime uses. Chosen via
+///     <see cref="SiloRuntimeOptions.SchedulerKind"/>.
+/// </summary>
+public enum SchedulerKind
+{
+    /// <summary>
+    ///     The established sharded-ready-queue scheduler (<c>ActivationScheduler</c>) with its stall
+    ///     watchdog and overflow-worker rescue. The default.
+    /// </summary>
+    Legacy = 0,
+
+    /// <summary>
+    ///     The next-generation arena scheduler (<c>ArenaScheduler</c>) — dedicated worker threads,
+    ///     per-worker work-stealing deques, and a shared injection queue. Phase 1: single arena, no NUMA
+    ///     affinity, one priority lane. Opt-in while later phases (priority lanes, affinity, cooperative
+    ///     async resume, rescue) land. See docs/superpowers/specs/2026-07-12-next-gen-scheduler-design.md.
+    /// </summary>
+    ArenaV2 = 1,
+}

--- a/src/Quark.Runtime/Scheduling/ArenaScheduler.cs
+++ b/src/Quark.Runtime/Scheduling/ArenaScheduler.cs
@@ -1,0 +1,537 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Quark.Diagnostics.Abstractions;
+
+namespace Quark.Runtime;
+
+/// <summary>
+///     Next-generation silo scheduler (Phase 1) — a fresh <see cref="IActivationScheduler"/> built on
+///     dedicated worker threads, per-worker work-stealing deques, and a shared injection queue. This is
+///     the P1 skeleton of the design in
+///     docs/superpowers/specs/2026-07-12-next-gen-scheduler-design.md: a single logical arena, no NUMA
+///     affinity, one priority lane/band. Later phases layer arenas, affinity, priority lanes, and
+///     cooperative cancellation on top of this loop without changing the seam.
+/// </summary>
+/// <remarks>
+///     <para><b>Model.</b> The schedulable unit is the <see cref="GrainActivation"/>, never the message.
+///     An activation becomes "ready" when it has undispatched mailbox work; the <c>_scheduled</c> CAS
+///     claim (via <see cref="GrainActivation.TryMarkScheduled"/>) guarantees it lives in exactly one
+///     queue and is drained by exactly one worker at a time. That single-ownership — not any per-grain
+///     lock — is what makes turns thread-safe, and it is what makes stealing safe: a stolen activation
+///     carries its exclusive claim.</para>
+///
+///     <para><b>Routing.</b> A schedule raised <em>from a worker thread</em> (grain-to-grain fan-out)
+///     goes onto that worker's local deque — LIFO, cache-warm, stealable. A schedule raised from any
+///     other thread (client/network/timer) and every budget-yield reschedule goes onto the shared
+///     <see cref="_injection"/> queue (FIFO, fair). Workers drain local-first for locality, poll the
+///     injection queue periodically so it can't starve, then steal from siblings.</para>
+///
+///     <para><b>Parking.</b> Uses the same lost-wakeup-free ordering the legacy scheduler proved out
+///     (see docs/superpowers/specs/2026-07-09-scheduler-wake-signal-sharding-design.md): a worker with
+///     no work pushes its index onto <see cref="_idleWorkers"/>, re-scans (double-check), then parks on
+///     its own semaphore. An enqueuer wakes one idle worker by popping the stack and releasing that
+///     worker's semaphore. A stale idle entry left after a double-check finds work is harmless — it is
+///     consumed later as a bounded spurious wake.</para>
+///
+///     <para><b>Async resume (spill-to-ThreadPool on await).</b> A turn that completes
+///     <em>synchronously</em> is drained inline on the dedicated worker thread — no async frame, no
+///     ThreadPool hop — the CPU-bound throughput fast path where thread/NUMA affinity pays off. The
+///     instant a turn <em>awaits</em>, the worker stops waiting on it: the drain's remainder runs as an
+///     async continuation (on the ThreadPool, since no per-worker <c>SynchronizationContext</c> is
+///     installed and the runtime drains with <c>ConfigureAwait(false)</c>), and the worker returns to
+///     its loop free to run other ready activations — including the very nested call the suspended turn
+///     is waiting on. This removes both the blocking-drain latency and the bounded-worker reentrancy
+///     deadlock (issue #167's failure mode): a non-reentrant call chain deeper than the worker count no
+///     longer starves, because no worker is ever blocked inside a turn. The activation's
+///     <c>_running</c>/<c>_scheduled</c> claims span the whole async drain (the drain method is
+///     suspended, not completed), so single-threaded-per-activation still holds across the await.
+///     Await-heavy turns lose thread affinity on resume, which is the right trade — they are I/O-bound,
+///     where NUMA locality is irrelevant.</para>
+///
+///     <para><b>Opt-in.</b> Selected only when <see cref="SiloRuntimeOptions.SchedulerKind"/> is
+///     <see cref="SchedulerKind.ArenaV2"/>; the default remains the legacy
+///     <see cref="ActivationScheduler"/> until the arena scheduler clears the full benchmark suite.
+///     Multi-arena / NUMA affinity and a stall/rescue watchdog for the residual all-workers-suspended
+///     edge remain later phases.</para>
+/// </remarks>
+internal sealed class ArenaScheduler : IActivationScheduler
+{
+    // Identifies the worker (and its local deque) for the currently-running worker thread, so
+    // ScheduleAsync can route a from-worker schedule to the local deque. Null on non-worker threads.
+    [ThreadStatic] private static WorkerHandle? _currentWorker;
+
+    private readonly WorkStealingDeque<GrainActivation>[] _deques;
+
+    // One injection sub-queue per worker, external schedules hashed by GrainId across them. Sharding
+    // the injection point (rather than one silo-wide queue) spreads producer/consumer contention across
+    // N independent MPMC queues — the same contention fix the legacy scheduler's sharded ready queue
+    // applies (docs/superpowers/specs/2026-07-08-scheduler-ready-queue-contention-fix.md). Workers
+    // service their own shard first and steal from the others, so nothing is stranded on a busy worker.
+    private readonly ConcurrentQueue<GrainActivation>[] _inject;
+
+    private readonly SemaphoreSlim[] _signals;
+    private readonly Thread[] _threads;
+    private readonly ConcurrentStack<int> _idleWorkers = new();
+
+    private readonly CancellationTokenSource _cts = new();
+    private readonly IQuarkDiagnosticListener _diagnostics;
+    private readonly int _drainBudget;
+    private readonly TimeSpan _shutdownStalledThreshold;
+
+    // In-flight backpressure (async-resume). _inFlight[i] = suspended (spilled) drains worker i holds;
+    // when it reaches _maxInFlight the worker stops taking new work and parks in ParkForSlot until one
+    // of its own drains completes. _capWaiting[i] is the Dekker-fenced flag a completing drain checks to
+    // decide whether to wake worker i. Only the spill (async) path touches these, so the synchronous
+    // drain fast path pays only a single Volatile.Read of _inFlight[i] (always 0 when nothing spills).
+    private readonly int _maxInFlight;
+    private readonly int[] _inFlight;
+    private readonly int[] _capWaiting;
+
+    // Validation counters — only touched when QUARK_SCHEDULER_STATS=1, so the hot path pays a single
+    // predictable-branch check and nothing else when stats are off. Used to prove whether a workload
+    // actually exercises from-worker (local-deque) routing and stealing, or is purely externally driven.
+    private bool _statsEnabled;
+    private long _localSchedules;
+    private long _externalSchedules;
+    private long _reschedules;
+    private long _steals;
+    private int _totalInFlight;   // stats-only: current silo-wide suspended drains
+    private int _peakInFlight;    // stats-only: high-water mark of _totalInFlight
+    private long _capParks;       // stats-only: times a worker hit the in-flight cap and parked
+
+    private volatile bool _disposed;
+
+    /// <summary>Test-only: turns on the validation counters programmatically (equivalent to QUARK_SCHEDULER_STATS=1).</summary>
+    internal void EnableStatsForTesting() => _statsEnabled = true;
+
+    /// <summary>Test-only: snapshot of the validation counters (external/local schedules, reschedules, steals).</summary>
+    internal (long External, long Local, long Reschedules, long Steals) StatsSnapshot()
+        => (Interlocked.Read(ref _externalSchedules),
+            Interlocked.Read(ref _localSchedules),
+            Interlocked.Read(ref _reschedules),
+            Interlocked.Read(ref _steals));
+
+    /// <summary>Test-only: high-water mark of silo-wide concurrent suspended drains (requires stats enabled).</summary>
+    internal int PeakInFlightForTesting() => Volatile.Read(ref _peakInFlight);
+
+    public ArenaScheduler(
+        SiloRuntimeOptions options,
+        IQuarkDiagnosticListener? diagnostics = null,
+        DiagnosticOptions? diagnosticOptions = null)
+    {
+        int workerCount = Math.Max(1, options.SchedulerMaxConcurrentActivations);
+        _drainBudget = Math.Max(1, options.SchedulerDrainBudget);
+        _maxInFlight = Math.Max(1, options.SchedulerMaxInFlightDrainsPerWorker);
+        _diagnostics = diagnostics ?? NullDiagnosticListener.Instance;
+        _shutdownStalledThreshold = (diagnosticOptions ?? new DiagnosticOptions()).ShutdownStalledThreshold;
+        _statsEnabled = Environment.GetEnvironmentVariable("QUARK_SCHEDULER_STATS") == "1";
+
+        _deques = new WorkStealingDeque<GrainActivation>[workerCount];
+        _inject = new ConcurrentQueue<GrainActivation>[workerCount];
+        _signals = new SemaphoreSlim[workerCount];
+        _threads = new Thread[workerCount];
+        _inFlight = new int[workerCount];
+        _capWaiting = new int[workerCount];
+
+        for (int i = 0; i < workerCount; i++)
+        {
+            _deques[i] = new WorkStealingDeque<GrainActivation>();
+            _inject[i] = new ConcurrentQueue<GrainActivation>();
+            _signals[i] = new SemaphoreSlim(0);
+        }
+
+        for (int i = 0; i < workerCount; i++)
+        {
+            int index = i;
+            var thread = new Thread(() => WorkerLoop(index))
+            {
+                IsBackground = true,
+                Name = $"quark-arena-worker-{index}",
+            };
+            _threads[i] = thread;
+            thread.Start();
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask ScheduleAsync(GrainActivation activation, CancellationToken cancellationToken = default)
+    {
+        if (!activation.TryMarkScheduled())
+            return ValueTask.CompletedTask; // already queued/draining — its owner will pick up new work
+
+        _diagnostics.OnSchedulerActivationScheduled(new SchedulerActivationScheduledEvent(activation.GrainId));
+
+        WorkerHandle? current = _currentWorker;
+        if (current is not null && current.Owner == this)
+        {
+            current.Local.PushBottom(activation); // from-worker fan-out → local deque (LIFO, warm)
+            if (_statsEnabled) Interlocked.Increment(ref _localSchedules);
+        }
+        else
+        {
+            _inject[ShardFor(activation)].Enqueue(activation); // external → hashed injection shard (FIFO, fair)
+            if (_statsEnabled) Interlocked.Increment(ref _externalSchedules);
+        }
+
+        Wake();
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>Stable-for-the-activation's-lifetime injection shard, so its reschedules stay on one worker.</summary>
+    private int ShardFor(GrainActivation activation)
+        => (activation.GrainId.GetHashCode() & 0x7FFFFFFF) % _inject.Length;
+
+    /// <summary>
+    ///     Re-queues an activation that yielded because it hit the drain budget with work still pending.
+    ///     Always routes to the injection queue (back of line) rather than the yielding worker's local
+    ///     deque, so a single hot grain cannot monopolize its worker — that is the fairness half of the
+    ///     worker budget.
+    /// </summary>
+    private void Reschedule(GrainActivation activation)
+    {
+        if (!activation.TryMarkScheduled())
+            return;
+
+        _inject[ShardFor(activation)].Enqueue(activation);
+        if (_statsEnabled) Interlocked.Increment(ref _reschedules);
+        Wake();
+    }
+
+    /// <summary>
+    ///     Wakes one parked worker, if any is idle. Busy workers discover new work via poll/steal, so
+    ///     the common all-busy path must stay off the shared idle stack: the cheap lock-free
+    ///     <see cref="ConcurrentStack{T}.IsEmpty"/> read short-circuits before the contended
+    ///     <c>TryPop</c> CAS. This only skips a wake when no worker is parked (nothing to wake); a
+    ///     worker that parks immediately afterward still catches the work via its post-park double-check,
+    ///     so no wake is lost.
+    /// </summary>
+    private void Wake()
+    {
+        if (!_idleWorkers.IsEmpty && _idleWorkers.TryPop(out int worker))
+            _signals[worker].Release();
+    }
+
+    private void WorkerLoop(int index)
+    {
+        WorkStealingDeque<GrainActivation> local = _deques[index];
+        _currentWorker = new WorkerHandle(this, local);
+        CancellationToken ct = _cts.Token;
+        long iteration = 0;
+
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                // Backpressure: if we are already holding the max suspended (spilled) drains, take on no
+                // more — park until one of ours completes and frees a slot. One Volatile.Read on the hot
+                // path; always 0 (never taken) for synchronously-completing workloads.
+                if (Volatile.Read(ref _inFlight[index]) >= _maxInFlight)
+                {
+                    if (!ParkForSlot(index, ct))
+                        return;
+                    continue;
+                }
+
+                GrainActivation? activation = FindWork(index, local, iteration++);
+                if (activation is not null)
+                {
+                    RunActivation(activation, ct, index);
+                    continue;
+                }
+
+                // No work found. Register idle, then re-scan (double-check) before parking. This
+                // push-then-recheck ordering closes the classic lost-wakeup race: any enqueue whose
+                // publish happens-before this push is seen by the re-scan; any enqueue after the push
+                // sees our idle entry and wakes us.
+                _idleWorkers.Push(index);
+
+                activation = FindWork(index, local, iteration++);
+                if (activation is not null)
+                {
+                    // The idle entry we pushed is intentionally left in place — a later enqueuer may
+                    // pop it and release our semaphore, producing at most one bounded spurious wake.
+                    RunActivation(activation, ct, index);
+                    continue;
+                }
+
+                try
+                {
+                    _signals[index].Wait(ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+            }
+        }
+        finally
+        {
+            _currentWorker = null;
+        }
+    }
+
+    /// <summary>Own injection shard + local deque (LIFO) for locality, then steal from siblings.</summary>
+    private GrainActivation? FindWork(int index, WorkStealingDeque<GrainActivation> local, long iteration)
+    {
+        // Every 64th iteration, service the injection shard first so a perpetually hot local deque
+        // cannot starve externally-scheduled or yielded work routed to this worker.
+        if ((iteration & 63) == 0 && _inject[index].TryDequeue(out GrainActivation? fair))
+            return fair;
+
+        if (local.TryPopBottom(out GrainActivation? localItem))
+            return localItem;
+
+        if (_inject[index].TryDequeue(out GrainActivation? injected))
+            return injected;
+
+        return TryStealFromSiblings(index);
+    }
+
+    private GrainActivation? TryStealFromSiblings(int index)
+    {
+        int n = _deques.Length;
+        if (n <= 1)
+            return null;
+
+        // Start one past ourselves and sweep, so thieves don't all converge on worker 0. Steal from
+        // both a victim's local deque and its injection shard, so work is never stranded on a busy
+        // worker's shard (its owner may be blocked in a long drain).
+        for (int i = 1; i < n; i++)
+        {
+            int victim = index + i;
+            if (victim >= n)
+                victim -= n;
+
+            if (_deques[victim].TrySteal(out GrainActivation? stolen))
+            {
+                if (_statsEnabled) Interlocked.Increment(ref _steals);
+                return stolen;
+            }
+
+            if (_inject[victim].TryDequeue(out GrainActivation? injected))
+            {
+                if (_statsEnabled) Interlocked.Increment(ref _steals);
+                return injected;
+            }
+        }
+
+        return null;
+    }
+
+    private void RunActivation(GrainActivation activation, CancellationToken ct, int workerIndex)
+    {
+        if (!activation.TryBeginDrain())
+        {
+            // Defensive: the _scheduled claim is held for the whole drain, so a second ready entry for
+            // an in-flight drain should never exist. If it somehow does and work remains, requeue it.
+            if (activation.HasPendingWork)
+                Reschedule(activation);
+            return;
+        }
+
+        _diagnostics.OnSchedulerDrainStarted(new SchedulerDrainStartedEvent(activation.GrainId));
+        long start = Stopwatch.GetTimestamp();
+
+        ValueTask<(ActivationDrainResult Result, bool NeedsReschedule)> drain;
+        try
+        {
+            drain = activation.DrainAndCompleteAsync(_drainBudget, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            return; // shutting down before the drain even started
+        }
+
+        if (drain.IsCompletedSuccessfully)
+        {
+            // Synchronously-completing turn: finish inline on this dedicated worker thread — no async
+            // frame, no ThreadPool hop. The CPU-bound throughput fast path.
+            (ActivationDrainResult result, bool needsReschedule) = drain.Result;
+            FinishDrain(activation, result, needsReschedule, start);
+        }
+        else
+        {
+            // The turn suspended on an await. Count it against this worker's in-flight budget (before
+            // starting the continuation, so a fast completion can never decrement below the increment),
+            // then spill the remainder to a ThreadPool continuation so this worker stays free instead of
+            // blocking — nested awaited calls then make progress on this same worker (or another), which
+            // removes both the blocking-drain latency and the bounded-worker reentrancy deadlock. The
+            // in-flight count is what the worker loop's backpressure gate reads. See the class remarks.
+            EnterInFlight(workerIndex);
+            _ = AwaitDrainAsync(drain, activation, start, workerIndex);
+        }
+    }
+
+    private async Task AwaitDrainAsync(
+        ValueTask<(ActivationDrainResult Result, bool NeedsReschedule)> drain,
+        GrainActivation activation,
+        long start,
+        int workerIndex)
+    {
+        try
+        {
+            (ActivationDrainResult result, bool needsReschedule) = await drain.ConfigureAwait(false);
+            FinishDrain(activation, result, needsReschedule, start);
+        }
+        catch (OperationCanceledException)
+        {
+            // shutting down mid-drain
+        }
+        finally
+        {
+            ExitInFlight(workerIndex);
+        }
+    }
+
+    /// <summary>Records a spilled (suspended) drain against a worker's in-flight budget.</summary>
+    private void EnterInFlight(int workerIndex)
+    {
+        Interlocked.Increment(ref _inFlight[workerIndex]);
+
+        if (_statsEnabled)
+        {
+            int total = Interlocked.Increment(ref _totalInFlight);
+            int peak;
+            while (total > (peak = Volatile.Read(ref _peakInFlight)) &&
+                   Interlocked.CompareExchange(ref _peakInFlight, total, peak) != peak)
+            {
+                // retry until the high-water mark reflects this total or a larger one already won
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Releases a worker's in-flight slot when a spilled drain completes and wakes the worker if it
+    ///     is parked in <see cref="ParkForSlot"/> waiting for a slot. The single-winner CAS on
+    ///     <c>_capWaiting</c> ensures exactly one completing drain releases the worker's semaphore per
+    ///     park, bounding permit inflation; the Dekker-style full fences (Interlocked here, and the
+    ///     Interlocked.Exchange before the re-read in ParkForSlot) guarantee no wake is lost.
+    /// </summary>
+    private void ExitInFlight(int workerIndex)
+    {
+        int now = Interlocked.Decrement(ref _inFlight[workerIndex]);
+        if (_statsEnabled)
+            Interlocked.Decrement(ref _totalInFlight);
+
+        if (now < _maxInFlight &&
+            Interlocked.CompareExchange(ref _capWaiting[workerIndex], 0, 1) == 1)
+        {
+            _signals[workerIndex].Release();
+        }
+    }
+
+    /// <summary>
+    ///     Parks a worker that has hit its in-flight cap until one of its own suspended drains completes
+    ///     and frees a slot. Publishes intent (<c>_capWaiting</c>) under a full fence, then re-checks the
+    ///     count (double-check) before committing to a wait, so a slot freed between the loop's gate and
+    ///     here is not missed. Returns <see langword="false"/> only on shutdown.
+    /// </summary>
+    private bool ParkForSlot(int index, CancellationToken ct)
+    {
+        Interlocked.Exchange(ref _capWaiting[index], 1); // publish intent + full fence (Dekker)
+
+        // Double-check: a completion may have freed a slot between the loop's gate read and this publish.
+        if (Volatile.Read(ref _inFlight[index]) < _maxInFlight)
+        {
+            Interlocked.Exchange(ref _capWaiting[index], 0);
+            return true;
+        }
+
+        if (_statsEnabled) Interlocked.Increment(ref _capParks);
+
+        try
+        {
+            _signals[index].Wait(ct);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+        finally
+        {
+            // Clear intent regardless of how we woke (completion CAS already cleared it, or spurious/cancel).
+            Interlocked.Exchange(ref _capWaiting[index], 0);
+        }
+    }
+
+    /// <summary>Post-drain bookkeeping shared by the inline (sync) and spilled (async) completion paths.</summary>
+    private void FinishDrain(GrainActivation activation, ActivationDrainResult result, bool needsReschedule, long start)
+    {
+        double drainMs = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+        _diagnostics.OnSchedulerDrainCompleted(
+            new SchedulerDrainCompletedEvent(activation.GrainId, result.ItemsProcessed, drainMs));
+
+        if (!result.IsCompleted && (result.HasMoreWork || needsReschedule))
+            Reschedule(activation);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+
+        await _cts.CancelAsync().ConfigureAwait(false);
+
+        // Wake every worker so parked ones observe cancellation and exit their loops.
+        foreach (SemaphoreSlim signal in _signals)
+            signal.Release();
+
+        // Join workers off the caller's thread so DisposeAsync stays asynchronous. A worker blocked in
+        // a genuinely async drain exits once DrainAsync observes the cancelled token, so joins are
+        // prompt in practice; surface a stalled shutdown rather than hanging silently if one does not.
+        await Task.Run(() =>
+        {
+            var stalled = false;
+            foreach (Thread thread in _threads)
+            {
+                if (!thread.Join(_shutdownStalledThreshold))
+                    stalled = true;
+                else if (stalled)
+                    thread.Join(); // already reported; wait out the remainder
+            }
+
+            if (stalled)
+            {
+                int pending = 0;
+                foreach (Thread thread in _threads)
+                {
+                    if (thread.IsAlive)
+                        pending++;
+                }
+
+                _diagnostics.OnSchedulerShutdownStalled(
+                    new SchedulerShutdownStalledEvent(pending, _threads.Length, _shutdownStalledThreshold));
+
+                foreach (Thread thread in _threads)
+                    thread.Join();
+            }
+        }).ConfigureAwait(false);
+
+        _cts.Dispose();
+        foreach (SemaphoreSlim signal in _signals)
+            signal.Dispose();
+
+        if (_statsEnabled)
+        {
+            long local = Interlocked.Read(ref _localSchedules);
+            long external = Interlocked.Read(ref _externalSchedules);
+            long total = local + external;
+            double localPct = total == 0 ? 0 : 100.0 * local / total;
+            Console.WriteLine(
+                $"[ArenaScheduler stats] workers={_threads.Length} maxInFlight/worker={_maxInFlight} " +
+                $"schedules: external={external:N0} local(from-worker)={local:N0} ({localPct:F1}%) " +
+                $"reschedules={Interlocked.Read(ref _reschedules):N0} steals={Interlocked.Read(ref _steals):N0} " +
+                $"peakInFlight={Volatile.Read(ref _peakInFlight):N0} capParks={Interlocked.Read(ref _capParks):N0}");
+        }
+    }
+
+    /// <summary>Per-worker-thread handle stored in <see cref="_currentWorker"/> for from-worker routing.</summary>
+    private sealed class WorkerHandle(ArenaScheduler owner, WorkStealingDeque<GrainActivation> local)
+    {
+        public ArenaScheduler Owner { get; } = owner;
+        public WorkStealingDeque<GrainActivation> Local { get; } = local;
+    }
+}

--- a/src/Quark.Runtime/Scheduling/WorkStealingDeque.cs
+++ b/src/Quark.Runtime/Scheduling/WorkStealingDeque.cs
@@ -1,0 +1,170 @@
+namespace Quark.Runtime;
+
+/// <summary>
+///     A single-producer / multi-consumer work-stealing deque, the per-worker local run queue of the
+///     next-generation <see cref="ArenaScheduler"/>. The owning worker pushes and pops at the
+///     <em>bottom</em> (LIFO — the freshest, cache-warmest item runs next); thieves take from the
+///     <em>top</em> (FIFO — the oldest item, fairest to hand off). Lock-free on both owner fast paths;
+///     the per-deque <see cref="_foreignLock"/> only serializes the 0-or-1-element boundary between a
+///     pop and a steal, plus array growth.
+///     <para>
+///         This is a faithful port of the algorithm the CLR ThreadPool uses for its
+///         <c>WorkStealingQueue&lt;T&gt;</c>: it is a proven design whose correctness rests on the
+///         owner reserving a slot by decrementing <see cref="_tailIndex"/> under an
+///         <see cref="Interlocked.Exchange(ref int, int)"/> full fence before reading it, and thieves
+///         reserving a slot by advancing <see cref="_headIndex"/> under the foreign lock. Only the
+///         owner thread may call <see cref="PushBottom"/> / <see cref="TryPopBottom"/>; any thread may
+///         call <see cref="TrySteal"/>.
+///     </para>
+/// </summary>
+internal sealed class WorkStealingDeque<T> where T : class
+{
+    private const int InitialSize = 32;
+
+    private volatile T?[] _array = new T?[InitialSize];
+    private volatile int _mask = InitialSize - 1;
+
+    // Owner advances _tailIndex; thieves advance _headIndex (under _foreignLock). Both are read by
+    // the opposite side, hence volatile.
+    private volatile int _headIndex;
+    private volatile int _tailIndex;
+
+    private readonly object _foreignLock = new();
+
+    /// <summary>Approximate element count. May be observed slightly stale by a non-owner; never negative.</summary>
+    public int Count
+    {
+        get
+        {
+            int count = _tailIndex - _headIndex;
+            return count < 0 ? 0 : count;
+        }
+    }
+
+    public bool IsEmpty => _headIndex >= _tailIndex;
+
+    /// <summary>Owner-only. Pushes an item onto the bottom of the deque.</summary>
+    public void PushBottom(T item)
+    {
+        int tail = _tailIndex;
+
+        // Fast path: there is room without the tail catching the head region.
+        if (tail < _headIndex + _mask)
+        {
+            Volatile.Write(ref _array[tail & _mask], item);
+            _tailIndex = tail + 1;
+            return;
+        }
+
+        // Slow path: (possibly) grow the backing array. Serialize against thieves.
+        lock (_foreignLock)
+        {
+            int head = _headIndex;
+            int count = _tailIndex - _headIndex;
+
+            if (count >= _mask)
+            {
+                // Grow: copy live elements into a fresh, doubled array reindexed from 0.
+                var newArray = new T?[_array.Length << 1];
+                for (int i = 0; i < _array.Length; i++)
+                    newArray[i] = _array[(i + head) & _mask];
+
+                _array = newArray;
+                _headIndex = 0;
+                _tailIndex = tail = count;
+                _mask = (_mask << 1) | 1;
+            }
+
+            Volatile.Write(ref _array[tail & _mask], item);
+            _tailIndex = tail + 1;
+        }
+    }
+
+    /// <summary>Owner-only. Pops an item from the bottom of the deque.</summary>
+    public bool TryPopBottom(out T? item)
+    {
+        while (true)
+        {
+            int tail = _tailIndex;
+            if (_headIndex >= tail)
+            {
+                item = null;
+                return false; // empty
+            }
+
+            // Reserve the slot by decrementing the tail under a full fence, so a concurrent
+            // TrySteal (which reads the tail after advancing the head) observes the reservation.
+            tail -= 1;
+            Interlocked.Exchange(ref _tailIndex, tail);
+
+            if (_headIndex <= tail)
+            {
+                // Uncontended: the thief works the head end and cannot reach this slot.
+                int idx = tail & _mask;
+                item = Volatile.Read(ref _array[idx]);
+                if (item is null)
+                    continue; // transient null during a grow/steal; re-read
+
+                _array[idx] = null;
+                return true;
+            }
+
+            // Contended: exactly 0 or 1 elements remain. Resolve against thieves under the lock.
+            lock (_foreignLock)
+            {
+                if (_headIndex <= tail)
+                {
+                    int idx = tail & _mask;
+                    item = _array[idx];
+                    _array[idx] = null;
+                    if (item is null)
+                        continue;
+                    return true;
+                }
+
+                // A thief took the last element; undo our tail reservation.
+                _tailIndex = tail + 1;
+                item = null;
+                return false;
+            }
+        }
+    }
+
+    /// <summary>Any thread. Steals an item from the top (oldest end) of the deque.</summary>
+    public bool TrySteal(out T? item)
+    {
+        item = null;
+
+        // Lock-free reject when clearly empty; avoids taking the foreign lock on the common miss.
+        if (_headIndex >= _tailIndex)
+            return false;
+
+        lock (_foreignLock)
+        {
+            int head = _headIndex;
+
+            // Reserve the head slot under a full fence, so a concurrent TryPopBottom observes it.
+            Interlocked.Exchange(ref _headIndex, head + 1);
+
+            if (head < _tailIndex)
+            {
+                int idx = head & _mask;
+                item = Volatile.Read(ref _array[idx]);
+                if (item is null)
+                {
+                    // Cannot happen while head < tail under the lock, but stay safe: undo.
+                    _headIndex = head;
+                    return false;
+                }
+
+                _array[idx] = null;
+                return true;
+            }
+
+            // Lost the race: the deque emptied under us. Undo the reservation.
+            _headIndex = head;
+            item = null;
+            return false;
+        }
+    }
+}

--- a/src/Quark.Runtime/SiloRuntimeOptions.cs
+++ b/src/Quark.Runtime/SiloRuntimeOptions.cs
@@ -73,6 +73,14 @@ public sealed class SiloRuntimeOptions
     public MailboxFullMode MailboxFullMode { get; set; } = MailboxFullMode.Wait;
 
     /// <summary>
+    ///     Selects the activation scheduler implementation. Default: <see cref="Quark.Runtime.SchedulerKind.Legacy"/>
+    ///     (the established sharded-ready-queue scheduler). Set to <see cref="Quark.Runtime.SchedulerKind.ArenaV2"/>
+    ///     to opt into the next-generation arena scheduler
+    ///     (see docs/superpowers/specs/2026-07-12-next-gen-scheduler-design.md).
+    /// </summary>
+    public SchedulerKind SchedulerKind { get; set; } = SchedulerKind.Legacy;
+
+    /// <summary>
     ///     Maximum number of concurrent activation drains the scheduler may run simultaneously.
     ///     Default: <see cref="Environment.ProcessorCount"/>; floor of 1.
     /// </summary>
@@ -84,6 +92,21 @@ public sealed class SiloRuntimeOptions
     ///     Default: <c>64</c>; floor of 1.
     /// </summary>
     public int SchedulerDrainBudget { get; set; } = 64;
+
+    /// <summary>
+    ///     <see cref="SchedulerKind.ArenaV2"/> only. Safety ceiling on the number of suspended
+    ///     (awaiting) activation drains a single worker may hold before it stops taking on new work and
+    ///     applies backpressure. The arena scheduler runs a synchronously-completing turn inline but
+    ///     lets an <em>awaiting</em> turn suspend and frees its worker to run more activations; this caps
+    ///     how many such suspensions accumulate per worker, bounding memory and open per-call scopes
+    ///     under a flood of slow-awaiting turns. Peak concurrent suspended drains silo-wide is
+    ///     approximately this value times the worker count. Must exceed the deepest legitimate
+    ///     non-reentrant call-nesting depth: the async-resume deadlock-freedom relies on a worker being
+    ///     able to take on the nested call it is awaiting, so a cap below the nesting depth would
+    ///     reintroduce the bounded-worker deadlock. The generous default only trips under pathological
+    ///     async fan-out. Default: <c>256</c>; floor of 1.
+    /// </summary>
+    public int SchedulerMaxInFlightDrainsPerWorker { get; set; } = 256;
 
     /// <summary>
     ///     Capacity of the scheduler's global ready queue. <c>0</c> (the default) means unbounded.

--- a/src/Quark.Runtime/StatelessWorker/StatelessWorkerRouter.cs
+++ b/src/Quark.Runtime/StatelessWorker/StatelessWorkerRouter.cs
@@ -23,6 +23,13 @@ internal sealed class StatelessWorkerRouter
     private readonly IPlacementStrategyResolver _placementResolver;
     private readonly SiloRuntimeOptions _options;
 
+    // Cached once so the GetOrAdd cache-hit path allocates nothing. Passing the ResolvePolicy method
+    // group directly to GetOrAdd would allocate a fresh Func delegate on every call (the factory is
+    // never invoked after the first miss), and TryGetPolicy runs for every grain call — including
+    // non-stateless-worker grains, which cache a null policy — so that delegate churn hit the whole
+    // dispatch hot path.
+    private readonly Func<GrainType, StatelessWorkerPoolPolicy?> _resolvePolicy;
+
     public StatelessWorkerRouter(
         IGrainTypeRegistry typeRegistry,
         IPlacementStrategyResolver placementResolver,
@@ -31,6 +38,7 @@ internal sealed class StatelessWorkerRouter
         _typeRegistry = typeRegistry;
         _placementResolver = placementResolver;
         _options = options.Value;
+        _resolvePolicy = ResolvePolicy;
     }
 
     /// <summary>
@@ -39,7 +47,7 @@ internal sealed class StatelessWorkerRouter
     /// </summary>
     public bool TryGetPolicy(GrainType grainType, out StatelessWorkerPoolPolicy policy)
     {
-        StatelessWorkerPoolPolicy? cached = _policyCache.GetOrAdd(grainType, ResolvePolicy);
+        StatelessWorkerPoolPolicy? cached = _policyCache.GetOrAdd(grainType, _resolvePolicy);
         if (cached is null)
         {
             policy = default;

--- a/src/Quark.Runtime/WorkerParkSignal.cs
+++ b/src/Quark.Runtime/WorkerParkSignal.cs
@@ -1,0 +1,134 @@
+using System.Threading.Tasks.Sources;
+
+namespace Quark.Runtime;
+
+/// <summary>
+///     A single-consumer, multi-producer async auto-reset event used to park an idle
+///     <see cref="ActivationScheduler"/> worker without the per-park heap allocation of
+///     <see cref="SemaphoreSlim.WaitAsync(CancellationToken)"/>. That method's cancelable slow path
+///     allocates a <c>CancellationPromise&lt;bool&gt;</c> + a cancellation-registration node (+ a
+///     linked <c>TaskNode</c>) on <em>every</em> park -- ~200 B/call in a hot ping-pong where a worker
+///     parks and wakes roughly once per grain call, and the dominant residual after the spin-before-park,
+///     state-passing, and bitmask-idle-registry fixes
+///     (docs/superpowers/specs/2026-07-13-low-alloc-dispatch-design.md, Part B slice (b)).
+///     <para>
+///         This source is awaited through a reusable <see cref="ManualResetValueTaskSourceCore{T}"/>,
+///         so a park allocates nothing: the awaiting worker's async state-machine box already exists for
+///         the life of <see cref="ActivationScheduler.RunWorkerAsync"/> (allocated once on its first
+///         suspension, reused across every park), and this source hands that box a bare
+///         <see cref="ValueTask"/> backed by <see langword="this"/>.
+///     </para>
+/// </summary>
+/// <remarks>
+///     <para><b>Concurrency contract.</b> Exactly one thread -- the owning worker -- ever calls
+///     <see cref="WaitAsync"/> (and, transitively, this source's <see cref="IValueTaskSource.GetResult"/>
+///     / <see cref="IValueTaskSource.OnCompleted"/> and the internal <c>_core.Reset()</c>). Any number of
+///     threads (enqueuers on a shard's empty-&gt;non-empty transition, plus <c>DisposeAsync</c>) may call
+///     <see cref="Set"/> concurrently. A three-state field (<c>Idle</c>/<c>Signaled</c>/<c>Waiting</c>)
+///     mutated only by CAS mediates every producer/consumer transition, so <c>_core</c> is touched by at
+///     most one thread at a time: the consumer resets/arms it while <c>Idle</c>, and a single producer
+///     completes it via the <c>Waiting-&gt;Idle</c> CAS.</para>
+///
+///     <para><b>Auto-reset (boolean, not a permit count).</b> Replacing a
+///     <c>SemaphoreSlim(0, int.MaxValue)</c> with a boolean event is safe because the scheduler's signal
+///     is an <em>edge-triggered wake</em>, not a work counter: after a single wake the worker loops and
+///     re-sweeps every shard (<see cref="ActivationScheduler.TryDequeueAny"/>) until a full sweep finds
+///     nothing, so one wake drains arbitrarily many ready activations. Collapsing several concurrent
+///     <see cref="Set"/> calls into one pending signal therefore only elides redundant no-op sweeps -- it
+///     can never strand ready work, because the work is found by the sweep, not counted by the signal.</para>
+///
+///     <para><b>Lost-wake freedom.</b> Preserves exactly the guarantee the <see cref="SemaphoreSlim"/> it
+///     replaces gave (a <c>Release</c> before a <c>Wait</c> stores a permit == a <see cref="Set"/> before a
+///     park stores <c>Signaled</c>). Combined with <see cref="ActivationScheduler.RunWorkerAsync"/>'s
+///     register-idle -&gt; double-check-sweep -&gt; park ordering, every interleaving of a racing
+///     <see cref="Set"/> against a parking worker leaves the worker either completed-and-sweeping or
+///     parked-with-a-pending-completion; none leaves it parked while a producer's signal is lost. See the
+///     inline notes on <see cref="WaitAsync"/>.</para>
+/// </remarks>
+internal sealed class WorkerParkSignal : IValueTaskSource
+{
+    private const int Idle = 0;      // no pending signal, no parked consumer
+    private const int Signaled = 1;  // a signal is pending (a Set arrived with no parked consumer)
+    private const int Waiting = 2;   // the consumer is parked, awaiting _core.SetResult
+
+    // Mutable struct field -- must NOT be readonly (Reset/SetResult mutate it in place).
+    private ManualResetValueTaskSourceCore<bool> _core;
+    private int _state;
+
+    public WorkerParkSignal()
+    {
+        // Complete a parked worker's await on the thread pool, never inline on the Set() caller's
+        // thread. A Set() caller is an enqueuer -- a client/network/timer thread or a grain-to-grain
+        // caller -- and must not be hijacked to synchronously run a grain drain. RunWorkerAsync awaits
+        // with ConfigureAwait(false), so with async completion the continuation lands on the pool.
+        _core.RunContinuationsAsynchronously = true;
+    }
+
+    /// <summary>
+    ///     Parks the calling worker until a signal is available, consuming exactly one signal. Returns a
+    ///     completed <see cref="ValueTask"/> synchronously if a signal is already pending. MUST be called
+    ///     by only one thread at a time (the owning worker) -- single-consumer.
+    /// </summary>
+    public ValueTask WaitAsync()
+    {
+        // Fast path: consume an already-pending signal without parking.
+        if (Interlocked.CompareExchange(ref _state, Idle, Signaled) == Signaled)
+            return ValueTask.CompletedTask;
+
+        // No pending signal. Arm the source, then publish Waiting. Only this (consumer) thread ever
+        // resets the core, so Reset here races with no concurrent core mutation: a producer touches
+        // _core only after winning the Waiting->Idle CAS below, which cannot fire until we publish Waiting.
+        _core.Reset();
+        short token = _core.Version;
+
+        int prev = Interlocked.CompareExchange(ref _state, Waiting, Idle);
+        if (prev == Signaled)
+        {
+            // A Set() slipped in after the fast-path CAS and marked Signaled -- it observed Idle (not
+            // Waiting), so it did NOT touch _core. Consume that signal and return completed rather than
+            // parking on a source no producer will ever complete.
+            Interlocked.CompareExchange(ref _state, Idle, Signaled);
+            return ValueTask.CompletedTask;
+        }
+
+        // prev == Idle: we are now Waiting; the next Set() completes _core for this token.
+        return new ValueTask(this, token);
+    }
+
+    /// <summary>
+    ///     Makes one signal available, waking a parked consumer if there is one. Idempotent while a signal
+    ///     is already pending (auto-reset: at most one pending signal). Callable from any thread.
+    /// </summary>
+    public void Set()
+    {
+        while (true)
+        {
+            switch (Volatile.Read(ref _state))
+            {
+                case Signaled:
+                    return; // already pending -- collapse (the woken consumer re-sweeps every shard anyway)
+
+                case Idle:
+                    if (Interlocked.CompareExchange(ref _state, Signaled, Idle) == Idle)
+                        return;
+                    break; // lost the race, re-read
+
+                default: // Waiting -- a consumer is parked; claim it and complete its source.
+                    if (Interlocked.CompareExchange(ref _state, Idle, Waiting) == Waiting)
+                    {
+                        _core.SetResult(true);
+                        return;
+                    }
+                    break; // lost the race, re-read
+            }
+        }
+    }
+
+    void IValueTaskSource.GetResult(short token) => _core.GetResult(token);
+
+    ValueTaskSourceStatus IValueTaskSource.GetStatus(short token) => _core.GetStatus(token);
+
+    void IValueTaskSource.OnCompleted(
+        Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+        => _core.OnCompleted(continuation, state, token, flags);
+}

--- a/tests/Quark.Performance/AllocByTypeProfiler.cs
+++ b/tests/Quark.Performance/AllocByTypeProfiler.cs
@@ -1,0 +1,178 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using Microsoft.Extensions.DependencyInjection;
+using Quark.Core.Abstractions.Hosting;
+using Quark.Core.Abstractions.Identity;
+using Quark.Performance.PingPong;
+using Quark.Runtime;
+using Quark.Serialization;
+
+namespace Quark.Performance;
+
+/// <summary>
+///     Per-type allocation attribution for a single grain call, on the real
+///     <see cref="LocalGrainCallInvoker"/> path. BenchmarkDotNet's MemoryDiagnoser reports total B/op but
+///     not <em>which types</em> allocate; this drives the same dispatch in a tight single-threaded loop
+///     under an in-process <c>GCAllocationTick</c> EventListener, so the residual after Part A
+///     (activation-scoped) can be broken down by type and the next reduction targeted at ground truth.
+///     Run: <c>dotnet run -c Release --project tests/Quark.Performance -- AllocByType [seconds]</c>.
+/// </summary>
+public static class AllocByTypeProfiler
+{
+    private static readonly GrainType PerCallType = new("PingPongGrain");
+    private static readonly GrainType ActivationType = new("ActivationPingPongGrain");
+
+    public static async Task RunAsync(string[] args)
+    {
+        double seconds = args.Length > 1 && double.TryParse(args[1], out double s) ? s : 5.0;
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddQuarkSerialization();
+        services.Configure<SiloRuntimeOptions>(o =>
+        {
+            o.ClusterId = "bench";
+            o.ServiceId = "bench";
+            o.SiloName = "silo0";
+        });
+        services.AddQuarkRuntime();
+        services.AddGrainBehavior<IPingPongGrain, PingPongGrainBehavior>();
+        await using ServiceProvider sp = services.BuildServiceProvider();
+
+        GrainTypeRegistry typeReg = sp.GetRequiredService<GrainTypeRegistry>();
+        typeReg.Register(PerCallType, typeof(PingPongGrainBehavior));
+        typeReg.Register(ActivationType, typeof(ActivationPingPongGrainBehavior));
+
+        var invoker = sp.GetRequiredService<IGrainCallInvoker>();
+        GrainId perCall = GrainId.Create(PerCallType, "b0");
+        GrainId activation = GrainId.Create(ActivationType, "b0");
+
+        // Pre-activate so we measure steady-state calls, not the one-time activation.
+        await invoker.InvokeVoidAsync(perCall, new PingPongBehavior_PingInvokable());
+        await invoker.InvokeVoidAsync(activation, new PingPongBehavior_PingInvokable());
+
+        Console.WriteLine($"=== Allocation-by-type: {seconds:F0}s per variant ===\n");
+        await MeasureAsync("Per-call (IGrainBehavior)", invoker, perCall, seconds);
+        await MeasureAsync("Activation-scoped (IActivationBehavior)", invoker, activation, seconds);
+    }
+
+    private static async Task MeasureAsync(string label, IGrainCallInvoker invoker, GrainId id, double seconds)
+    {
+        // Warm up (JIT + pools) outside the measured window.
+        for (int i = 0; i < 50_000; i++)
+        {
+            await invoker.InvokeVoidAsync(id, new PingPongBehavior_PingInvokable());
+        }
+
+        using var listener = new AllocationTickListener();
+        long calls = 0;
+        long allocBefore = GC.GetTotalAllocatedBytes(precise: false);
+        listener.Start();
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed.TotalSeconds < seconds)
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                await invoker.InvokeVoidAsync(id, new PingPongBehavior_PingInvokable());
+            }
+            calls += 1000;
+        }
+
+        listener.Stop();
+        long allocDelta = GC.GetTotalAllocatedBytes(precise: false) - allocBefore;
+
+        Console.WriteLine($"--- {label} ---");
+        Console.WriteLine($"  calls: {calls:N0}   total: {allocDelta:N0} B   per-call: {(double)allocDelta / calls:N1} B");
+        long sampled = listener.TotalSampled;
+        foreach ((string type, long bytes) in listener.Top(15))
+        {
+            double perCall = (double)bytes / calls;
+            double pct = sampled > 0 ? 100.0 * bytes / sampled : 0;
+            Console.WriteLine($"    {perCall,7:N1} B/call {pct,5:F1}%  {Short(type)}");
+        }
+
+        Console.WriteLine();
+    }
+
+    private static string Short(string typeName)
+    {
+        // Keep enough of the namespace to tell mailbox (System.Threading.Channels) apart from
+        // scheduler/runtime allocators — the bare leaf name collides across both.
+        string t = typeName;
+        int bracket = t.IndexOf('[');
+        string head = bracket >= 0 ? t[..bracket] : t;
+        string tail = bracket >= 0 ? t[bracket..] : "";
+        string[] parts = head.Split('.');
+        string shortHead = parts.Length >= 2 ? $"{parts[^2]}.{parts[^1]}" : head;
+        return shortHead + tail;
+    }
+
+    // Counts GCAllocationTick bytes by allocated type name. AllocationTick fires roughly every ~100 KB
+    // allocated of a given type, and its AllocationAmount payload is that delta — summing it per type
+    // gives a proportional per-type allocation histogram, which MemoryDiagnoser's single total cannot.
+    private sealed class AllocationTickListener : EventListener
+    {
+        private readonly ConcurrentDictionary<string, long> _byType = new();
+        private volatile bool _enabled;
+
+        public long TotalSampled { get; private set; }
+
+        protected override void OnEventSourceCreated(EventSource source)
+        {
+            if (source.Name == "Microsoft-Windows-DotNETRuntime")
+            {
+                // Keyword 0x1 = GC; AllocationTick is emitted at Verbose.
+                EnableEvents(source, EventLevel.Verbose, (EventKeywords)0x1);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs e)
+        {
+            if (!_enabled || e.EventName is null || !e.EventName.StartsWith("GCAllocationTick", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            IReadOnlyList<string>? names = e.PayloadNames;
+            IReadOnlyList<object?>? payload = e.Payload;
+            if (names is null || payload is null)
+            {
+                return;
+            }
+
+            string type = "?";
+            long amount = 0;
+            for (int i = 0; i < names.Count; i++)
+            {
+                switch (names[i])
+                {
+                    case "TypeName":
+                        type = payload[i]?.ToString() ?? "?";
+                        break;
+                    case "AllocationAmount64":
+                        amount = payload[i] is not null ? Convert.ToInt64(payload[i]) : 0;
+                        break;
+                }
+            }
+
+            if (amount <= 0)
+            {
+                return;
+            }
+
+            _byType.AddOrUpdate(type, amount, (_, v) => v + amount);
+        }
+
+        public void Start() => _enabled = true;
+
+        public void Stop()
+        {
+            _enabled = false;
+            TotalSampled = _byType.Values.Sum();
+        }
+
+        public IEnumerable<KeyValuePair<string, long>> Top(int n)
+            => _byType.OrderByDescending(kv => kv.Value).Take(n);
+    }
+}

--- a/tests/Quark.Performance/AstroSim/AstroSimRunner.cs
+++ b/tests/Quark.Performance/AstroSim/AstroSimRunner.cs
@@ -22,6 +22,7 @@ public static class AstroSimRunner
 
         Console.WriteLine("=== AstroSim Throughput Benchmark ===");
         Console.WriteLine($"  Bodies: {cli.Bodies:N0}, Grid: {cli.Grid}^3 ({totalChunks:N0} chunks), Duration: {cli.DurationSeconds}s");
+        Console.WriteLine($"  Scheduler: {(cli.SchedulerV2 ? "ArenaScheduler (V2)" : "ActivationScheduler (legacy)")}");
         Console.WriteLine();
 
         await using TestCluster cluster = await TestCluster.CreateAsync(options =>
@@ -30,6 +31,8 @@ public static class AstroSimRunner
             options.ConfigureSiloServices = services =>
             {
                 services.AddQuarkRuntime();
+                if (cli.SchedulerV2)
+                    services.Configure<SiloRuntimeOptions>(o => o.SchedulerKind = SchedulerKind.ArenaV2);
                 services.AddQuarkDiagnostics(listener);
 
                 // AddQuarkDiagnostics's own TryAddSingleton<IQuarkDiagnosticListener> silently loses to
@@ -149,12 +152,14 @@ internal sealed class AstroSimCliArgs
     public int Bodies { get; private init; } = 10_000_000;
     public int Grid { get; private init; } = 32;
     public double DurationSeconds { get; private init; } = 10;
+    public bool SchedulerV2 { get; private init; }
 
     public static AstroSimCliArgs Parse(string[] args)
     {
         int bodies = 10_000_000;
         int grid = 32;
         double duration = 10;
+        bool schedulerV2 = false;
 
         for (int i = 1; i < args.Length; i++)
         {
@@ -169,9 +174,12 @@ internal sealed class AstroSimCliArgs
                 case "--duration" when i + 1 < args.Length:
                     duration = double.Parse(args[++i]);
                     break;
+                case "--v2":
+                    schedulerV2 = true;
+                    break;
             }
         }
 
-        return new AstroSimCliArgs { Bodies = bodies, Grid = grid, DurationSeconds = duration };
+        return new AstroSimCliArgs { Bodies = bodies, Grid = grid, DurationSeconds = duration, SchedulerV2 = schedulerV2 };
     }
 }

--- a/tests/Quark.Performance/DispatchPipelineBenchmarks.cs
+++ b/tests/Quark.Performance/DispatchPipelineBenchmarks.cs
@@ -22,6 +22,7 @@ namespace Quark.Performance;
 public class DispatchPipelineBenchmarks
 {
     private static readonly GrainType PingPongGrainType = new("PingPongGrain");
+    private static readonly GrainType ActivationPingPongGrainType = new("ActivationPingPongGrain");
     private static readonly Func<ValueTask<GrainActivation>> ThrowingFactory =
         static () => throw new InvalidOperationException("Factory should not run — activation must already exist.");
     private static readonly Func<ValueTask> NoOpWorkItem = static () => default;
@@ -30,6 +31,7 @@ public class DispatchPipelineBenchmarks
     private GrainActivationTable _activationTable = null!;
     private IGrainCallInvoker _invoker = null!;
     private GrainId _grainId;
+    private GrainId _activationGrainId;
     private GrainActivation _bareActivation = null!;
     private GrainActivation _bareActivationReentrant = null!;
 
@@ -69,14 +71,20 @@ public class DispatchPipelineBenchmarks
         services.AddGrainBehavior<IPingPongGrain, PingPongGrainBehavior>();
         _sp = services.BuildServiceProvider();
 
-        _sp.GetRequiredService<GrainTypeRegistry>().Register(PingPongGrainType, typeof(PingPongGrainBehavior));
+        GrainTypeRegistry typeReg = _sp.GetRequiredService<GrainTypeRegistry>();
+        typeReg.Register(PingPongGrainType, typeof(PingPongGrainBehavior));
+        // Part A: register the per-activation (IActivationBehavior) variant so the activation-scoped
+        // dispatch path can be measured against the per-call FullInvokeVoidAsync baseline.
+        typeReg.Register(ActivationPingPongGrainType, typeof(ActivationPingPongGrainBehavior));
 
         _activationTable = _sp.GetRequiredService<GrainActivationTable>();
         _invoker = _sp.GetRequiredService<IGrainCallInvoker>();
         _grainId = GrainId.Create(PingPongGrainType, "bench-0");
+        _activationGrainId = GrainId.Create(ActivationPingPongGrainType, "bench-act-0");
 
         // Pre-activate so the table-lookup and full-invoke benchmarks hit steady state.
         await _invoker.InvokeVoidAsync(_grainId, new PingPongBehavior_PingInvokable());
+        await _invoker.InvokeVoidAsync(_activationGrainId, new PingPongBehavior_PingInvokable());
 
         // Bare activations, constructed directly (bypassing GrainActivationTable) so mailbox-only
         // stages measure the channel/scheduler cost in isolation from DI/behavior resolution.
@@ -194,6 +202,13 @@ public class DispatchPipelineBenchmarks
     [Benchmark]
     public async ValueTask FullInvokeVoidAsync()
         => await _invoker.InvokeVoidAsync(_grainId, new PingPongBehavior_PingInvokable());
+
+    // Stage 8b: same complete call, but against an IActivationBehavior grain (Part A). Uses the cached
+    // per-activation instance + scope, so the ~792 B/call of ServiceScope create + DI resolution
+    // (stage 3) should drop out. The Allocated delta vs FullInvokeVoidAsync is Part A's payoff.
+    [Benchmark]
+    public async ValueTask FullInvokeVoidAsync_ActivationScoped()
+        => await _invoker.InvokeVoidAsync(_activationGrainId, new PingPongBehavior_PingInvokable());
 
     // Stage 9a: write + await a forced-async completion signal — Quark's real RPC-await pattern.
     [Benchmark]

--- a/tests/Quark.Performance/PingPong/ActivationPingPongGrainBehavior.cs
+++ b/tests/Quark.Performance/PingPong/ActivationPingPongGrainBehavior.cs
@@ -1,0 +1,14 @@
+using Quark.Core.Abstractions.Grains;
+
+namespace Quark.Performance.PingPong;
+
+/// <summary>
+///     Per-activation (<see cref="IActivationBehavior"/>) variant of <see cref="PingPongGrainBehavior"/>,
+///     used to measure the allocation delta of the activation-scoped dispatch path (one cached instance +
+///     scope) versus the default per-call model. Implements the same <see cref="IPingPongGrain"/> so the
+///     existing invokable dispatches to it unchanged.
+/// </summary>
+public sealed class ActivationPingPongGrainBehavior : IActivationBehavior, IPingPongGrain
+{
+    public ValueTask PingAsync() => default;
+}

--- a/tests/Quark.Performance/PingPong/PingPongRunner.cs
+++ b/tests/Quark.Performance/PingPong/PingPongRunner.cs
@@ -20,9 +20,12 @@ public static class PingPongRunner
         PingPongCliArgs cli = PingPongCliArgs.Parse(args);
         string mode = cli.Bare ? "Bare (no DI/scope resolution)" : cli.Reentrant ? "Reentrant" : "Non-reentrant";
 
+        string schedulerName = cli.Bare ? "SimpleActivationScheduler" : cli.SchedulerV2 ? "ArenaScheduler (V2)" : "ActivationScheduler (legacy)";
+
         Console.WriteLine("=== Ping-Pong Throughput Benchmark ===");
         Console.WriteLine($"  Pairs: {cli.Pairs}, Duration: {cli.DurationSeconds}s, Mode: {mode}");
-        Console.WriteLine($"  Scheduler workers: {cli.SchedulerWorkers}{(cli.Bare ? " (ignored -- --bare bypasses ActivationScheduler entirely)" : "")}");
+        Console.WriteLine($"  Scheduler: {schedulerName}");
+        Console.WriteLine($"  Scheduler workers: {cli.SchedulerWorkers}{(cli.Bare ? " (ignored -- --bare bypasses the scheduler entirely)" : "")}");
         if (cli.Bare)
         {
             Console.WriteLine("  Bare mode: bypasses LocalGrainCallInvoker/GrainScopeBinder entirely -- posts");
@@ -67,9 +70,22 @@ public static class PingPongRunner
                 // force ActivationScheduler here so --scheduler-workers has any effect at all. A plain
                 // AddSingleton after AddQuarkRuntime() wins DI's last-registration-wins resolution over
                 // the TryAdd default. See docs/superpowers/specs/2026-07-12-scheduler-sweep-scaling-investigation.md.
-                services.AddSingleton<IActivationScheduler>(sp => new ActivationScheduler(
-                    sp.GetRequiredService<IOptions<SiloRuntimeOptions>>().Value,
-                    sp.GetService<IQuarkDiagnosticListener>()));
+                // --v2 selects the next-generation ArenaScheduler (dedicated worker threads,
+                // per-worker work-stealing deques — see
+                // docs/superpowers/specs/2026-07-12-next-gen-scheduler-design.md). Same
+                // last-registration-wins override as the legacy path below.
+                if (cli.SchedulerV2)
+                {
+                    services.AddSingleton<IActivationScheduler>(sp => new ArenaScheduler(
+                        sp.GetRequiredService<IOptions<SiloRuntimeOptions>>().Value,
+                        sp.GetService<IQuarkDiagnosticListener>()));
+                }
+                else
+                {
+                    services.AddSingleton<IActivationScheduler>(sp => new ActivationScheduler(
+                        sp.GetRequiredService<IOptions<SiloRuntimeOptions>>().Value,
+                        sp.GetService<IQuarkDiagnosticListener>()));
+                }
 
                 services.AddQuarkDiagnostics(new BenchmarkDiagnosticListener());
                 services.AddGrainBehavior<IPingPongGrain, PingPongGrainBehavior>();
@@ -241,6 +257,7 @@ internal sealed class PingPongCliArgs
     public double DurationSeconds { get; private init; } = 10;
     public bool Reentrant { get; private init; }
     public bool Bare { get; private init; }
+    public bool SchedulerV2 { get; private init; }
 
     public static PingPongCliArgs Parse(string[] args)
     {
@@ -249,6 +266,7 @@ internal sealed class PingPongCliArgs
         double duration = 10;
         bool reentrant = false;
         bool bare = false;
+        bool schedulerV2 = false;
 
         for (int i = 1; i < args.Length; i++)
         {
@@ -269,6 +287,9 @@ internal sealed class PingPongCliArgs
                 case "--bare":
                     bare = true;
                     break;
+                case "--v2":
+                    schedulerV2 = true;
+                    break;
             }
         }
 
@@ -279,6 +300,7 @@ internal sealed class PingPongCliArgs
             DurationSeconds = duration,
             Reentrant = reentrant,
             Bare = bare,
+            SchedulerV2 = schedulerV2,
         };
     }
 }

--- a/tests/Quark.Performance/Program.cs
+++ b/tests/Quark.Performance/Program.cs
@@ -92,6 +92,13 @@ public class Program
             return;
         }
 
+        // Per-type allocation attribution for a single grain call (in-process GCAllocationTick listener).
+        if (args.Length > 0 && args[0].Equals("AllocByType", StringComparison.OrdinalIgnoreCase))
+        {
+            await AllocByTypeProfiler.RunAsync(args);
+            return;
+        }
+
         // Otherwise run BenchmarkDotNet benchmarks
         var switcher = new BenchmarkSwitcher(new[]
         {

--- a/tests/Quark.Tests.CodeGenerator/BehaviorStateAnalyzerTests.cs
+++ b/tests/Quark.Tests.CodeGenerator/BehaviorStateAnalyzerTests.cs
@@ -380,4 +380,140 @@ public sealed class BehaviorStateAnalyzerTests
 
         Assert.DoesNotContain(diagnostics, d => d.Id == "QRK0022");
     }
+
+    // -----------------------------------------------------------------------
+    // IActivationBehavior — per-activation instance: mutable fields/props allowed
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Does_Not_Report_MutableField_On_ActivationBehavior()
+    {
+        const string source = """
+            using Quark.Core.Abstractions.Grains;
+
+            namespace Demo;
+
+            public interface IMyGrain : IGrain { }
+
+            public sealed class MyBehavior : IActivationBehavior, IMyGrain
+            {
+                private long _count;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = AnalyzerTestDriver.Run(source, new BehaviorStateAnalyzer());
+
+        // The instance lives for the whole activation, so mutable fields are legitimate state.
+        Assert.DoesNotContain(diagnostics, d => d.Id == "QRK0020");
+    }
+
+    [Fact]
+    public void Does_Not_Report_WritableAutoProperty_On_ActivationBehavior()
+    {
+        const string source = """
+            using Quark.Core.Abstractions.Grains;
+
+            namespace Demo;
+
+            public interface IMyGrain : IGrain { }
+
+            public sealed class MyBehavior : IActivationBehavior, IMyGrain
+            {
+                public string? Name { get; set; }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = AnalyzerTestDriver.Run(source, new BehaviorStateAnalyzer());
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "QRK0021");
+    }
+
+    [Fact]
+    public void Reports_MutableStaticField_On_ActivationBehavior()
+    {
+        const string source = """
+            using Quark.Core.Abstractions.Grains;
+
+            namespace Demo;
+
+            public interface IMyGrain : IGrain { }
+
+            public sealed class MyBehavior : IActivationBehavior, IMyGrain
+            {
+                private static int s_shared;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = AnalyzerTestDriver.Run(source, new BehaviorStateAnalyzer());
+
+        // Statics are shared across all activations regardless of the instance-lifetime model.
+        Assert.Contains(diagnostics, d => d.Id == "QRK0022");
+    }
+
+    // -----------------------------------------------------------------------
+    // QRK0023 — IActivationBehavior on a reentrant grain
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Reports_ReentrantActivationBehavior()
+    {
+        const string source = """
+            using Quark.Core.Abstractions.Grains;
+
+            namespace Demo;
+
+            public interface IMyGrain : IGrain { }
+
+            [Reentrant]
+            public sealed class MyBehavior : IActivationBehavior, IMyGrain
+            {
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = AnalyzerTestDriver.Run(source, new BehaviorStateAnalyzer());
+
+        Assert.Contains(diagnostics, d => d.Id == "QRK0023");
+    }
+
+    [Fact]
+    public void Does_Not_Report_QRK0023_On_NonReentrant_ActivationBehavior()
+    {
+        const string source = """
+            using Quark.Core.Abstractions.Grains;
+
+            namespace Demo;
+
+            public interface IMyGrain : IGrain { }
+
+            public sealed class MyBehavior : IActivationBehavior, IMyGrain
+            {
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = AnalyzerTestDriver.Run(source, new BehaviorStateAnalyzer());
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "QRK0023");
+    }
+
+    [Fact]
+    public void Does_Not_Report_QRK0023_On_Reentrant_PerCallBehavior()
+    {
+        const string source = """
+            using Quark.Core.Abstractions.Grains;
+
+            namespace Demo;
+
+            public interface IMyGrain : IGrain { }
+
+            [Reentrant]
+            public sealed class MyBehavior : IGrainBehavior, IMyGrain
+            {
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = AnalyzerTestDriver.Run(source, new BehaviorStateAnalyzer());
+
+        // [Reentrant] is fine on the default per-call model — QRK0023 is specific to IActivationBehavior.
+        Assert.DoesNotContain(diagnostics, d => d.Id == "QRK0023");
+    }
 }

--- a/tests/Quark.Tests.Unit/SchedulingSemantics/ActivationSchedulerShutdownRejectsScheduleTests.cs
+++ b/tests/Quark.Tests.Unit/SchedulingSemantics/ActivationSchedulerShutdownRejectsScheduleTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Quark.Core.Abstractions.Identity;
+using Quark.Runtime;
+using Xunit;
+
+namespace Quark.Tests.Unit.SchedulingSemantics;
+
+/// <summary>
+///     Regression coverage for a deactivation-during-shutdown hang. Once
+///     <see cref="ActivationScheduler.DisposeAsync"/> has begun, its drain workers exit, so any
+///     activation scheduled afterwards would never be drained. <see cref="GrainActivation.DisposeAsync"/>
+///     posts its own <c>OnDeactivate</c> turn through the scheduler during teardown and then awaits that
+///     drain, so a silently-accepted-but-never-drained enqueue hangs the poster forever.
+///     <para>
+///         The earlier <c>Channel&lt;GrainActivation&gt;</c>-based ready queue made
+///         <c>ScheduleAsync</c> throw <c>ChannelClosedException</c> once the channel completed on
+///         shutdown, which drove the activation's inline-drain fallback
+///         (<c>GrainActivation.DrainDirectlyAndDeactivateAsync</c>). The <see cref="System.Collections.Concurrent.ConcurrentQueue{T}"/>
+///         that replaced it has no closed state, so the reject-on-shutdown contract is now enforced
+///         explicitly by <see cref="ActivationScheduler.ScheduleAsync"/>. These tests lock that contract
+///         in: the surfaced hang was invisible to the old test suite because a since-removed
+///         <c>SemaphoreSlim</c> park primitive happened to make the post-dispose wake throw
+///         <see cref="ObjectDisposedException"/> for an unrelated reason (a disposed semaphore), masking
+///         the missing guard.
+///     </para>
+/// </summary>
+public sealed class ActivationSchedulerShutdownRejectsScheduleTests
+{
+    [Fact]
+    public async Task ScheduleAsync_AfterDispose_ThrowsObjectDisposed()
+    {
+        var options = new SiloRuntimeOptions { SchedulerMaxConcurrentActivations = 2 };
+        var scheduler = new ActivationScheduler(options);
+
+        var services = new ServiceCollection();
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        var grainType = new GrainType("ShutdownRejectProbe");
+        var activation = new GrainActivation(
+            new GrainId(grainType, "g"), grainType, isReentrant: false,
+            provider, NullLogger<GrainActivation>.Instance, scheduler);
+
+        await scheduler.DisposeAsync();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            async () => await scheduler.ScheduleAsync(activation));
+    }
+
+    [Fact]
+    public async Task ActivationDisposeAsync_AfterSchedulerDisposed_CompletesWithoutHanging()
+    {
+        var options = new SiloRuntimeOptions { SchedulerMaxConcurrentActivations = 2 };
+        var scheduler = new ActivationScheduler(options);
+
+        var services = new ServiceCollection();
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        var grainType = new GrainType("ShutdownDeactivateProbe");
+        var activation = new GrainActivation(
+            new GrainId(grainType, "g"), grainType, isReentrant: false,
+            provider, NullLogger<GrainActivation>.Instance, scheduler);
+
+        // Drive one real turn so the activation is genuinely live on the scheduler before shutdown.
+        await activation.PostAsync(() => ValueTask.CompletedTask);
+
+        // Scheduler goes down first (mirrors the DI dispose order the runtime uses): its workers exit.
+        await scheduler.DisposeAsync();
+
+        // The activation is disposed afterwards (as GrainActivationTable does). Its OnDeactivate turn can
+        // no longer be scheduler-driven, so it must fall back to draining inline and complete promptly --
+        // never block awaiting a drain the dead scheduler will never perform.
+        Task disposeActivation = activation.DisposeAsync().AsTask();
+        Task completed = await Task.WhenAny(disposeActivation, Task.Delay(TimeSpan.FromSeconds(10)));
+
+        Assert.Same(disposeActivation, completed); // would time out (hang) before the ScheduleAsync guard
+        await disposeActivation; // observe any fault
+    }
+}

--- a/tests/Quark.Tests.Unit/SchedulingSemantics/ActivationScopedBehaviorTests.cs
+++ b/tests/Quark.Tests.Unit/SchedulingSemantics/ActivationScopedBehaviorTests.cs
@@ -1,0 +1,222 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Quark.Core.Abstractions.Grains;
+using Quark.Core.Abstractions.Hosting;
+using Quark.Core.Abstractions.Identity;
+using Quark.Serialization.Abstractions.Buffers;
+using Quark.Runtime;
+using Xunit;
+
+namespace Quark.Tests.Unit.SchedulingSemantics;
+
+/// <summary>
+///     Part A slice (a): verifies the per-activation behavior model (<see cref="IActivationBehavior"/>).
+///     A single behavior instance + a single service scope live for the whole activation — constructed
+///     once, reused for every call (so instance fields persist across calls), and disposed on
+///     deactivation. Reentrant + activation-scoped is rejected. Drives the real
+///     <see cref="LocalGrainCallInvoker"/> dispatch path so it exercises the actual fast path, not a
+///     direct mailbox post.
+/// </summary>
+public sealed class ActivationScopedBehaviorTests
+{
+    [Fact]
+    public async Task ActivationBehavior_ConstructedOnce_InstanceReusedAcrossCalls()
+    {
+        await using var f = new Fixture();
+        GrainId id = GrainId.Create(new GrainType("ActCounter"), "a");
+
+        long r1 = await f.Invoker.InvokeAsync<IncrementInvokable, long>(id, default);
+        long r2 = await f.Invoker.InvokeAsync<IncrementInvokable, long>(id, default);
+        long r3 = await f.Invoker.InvokeAsync<IncrementInvokable, long>(id, default);
+
+        // Field persisted across calls → same instance handled all three.
+        Assert.Equal(1, r1);
+        Assert.Equal(2, r2);
+        Assert.Equal(3, r3);
+        // Constructed exactly once for the activation, not once per call.
+        Assert.Equal(1, f.Probe.Constructions);
+    }
+
+    [Fact]
+    public async Task ActivationBehavior_Deactivation_DisposesActivationScope_AndRunsOnDeactivateOnSameInstance()
+    {
+        await using var f = new Fixture();
+        GrainId id = GrainId.Create(new GrainType("ActCounter"), "b");
+
+        await f.Invoker.InvokeAsync<IncrementInvokable, long>(id, default);
+        await f.Invoker.InvokeAsync<IncrementInvokable, long>(id, default);
+
+        Assert.Equal(0, f.Probe.ScopeDisposals);
+
+        // Deactivate the activation and wait for teardown.
+        Assert.True(f.ActivationTable.TryGetActivation(id, out GrainActivation? activation));
+        await activation!.DisposeAsync();
+
+        // OnDeactivateAsync saw the accumulated count (same cached instance), and the activation scope
+        // (and the scoped IDisposable resolved into it) was disposed exactly once.
+        Assert.Equal(2, f.Probe.DeactivateObservedCount);
+        Assert.Equal(1, f.Probe.ScopeDisposals);
+    }
+
+    [Fact]
+    public async Task ActivationBehavior_FreshActivation_StartsWithFreshState()
+    {
+        await using var f = new Fixture();
+        GrainId id = GrainId.Create(new GrainType("ActCounter"), "c");
+
+        Assert.Equal(1, await f.Invoker.InvokeAsync<IncrementInvokable, long>(id, default));
+
+        Assert.True(f.ActivationTable.TryGetActivation(id, out GrainActivation? activation));
+        await activation!.DisposeAsync();
+
+        // A new activation of the same grain id constructs a new instance with fresh field state.
+        Assert.Equal(1, await f.Invoker.InvokeAsync<IncrementInvokable, long>(id, default));
+        Assert.Equal(2, f.Probe.Constructions);
+    }
+
+    [Fact]
+    public async Task ReentrantActivationBehavior_Throws_NotSupported()
+    {
+        await using var f = new Fixture();
+        GrainId id = GrainId.Create(new GrainType("ReentrantAct"), "r");
+
+        await Assert.ThrowsAsync<NotSupportedException>(
+            async () => await f.Invoker.InvokeVoidAsync<NoopInvokable>(id, default));
+    }
+
+    // ----- hand-wired invokables -----
+
+    private readonly struct IncrementInvokable : IGrainInvokable<long>
+    {
+        public uint MethodId => 0u;
+        public ValueTask<long> Invoke(IGrainBehavior behavior) => new(((IActivationCounterGrain)behavior).IncrementAsync());
+        public void Serialize(ref CodecWriter writer) { }
+        public long DeserializeResult(ref CodecReader reader) => reader.ReadInt64();
+    }
+
+    private readonly struct NoopInvokable : IGrainVoidInvokable
+    {
+        public uint MethodId => 0u;
+        public ValueTask Invoke(IGrainBehavior behavior) => new(((IReentrantActGrain)behavior).NoopAsync());
+        public void Serialize(ref CodecWriter writer) { }
+    }
+
+    // ----- test grains / behaviors -----
+
+    public interface IActivationCounterGrain : IGrainWithStringKey
+    {
+        Task<long> IncrementAsync();
+    }
+
+    public interface IReentrantActGrain : IGrainWithStringKey
+    {
+        Task NoopAsync();
+    }
+
+    // A per-activation behavior with mutable field state (allowed for IActivationBehavior).
+    private sealed class ActivationCounterBehavior : IActivationBehavior, IActivationCounterGrain, IActivationLifecycle
+    {
+        private readonly Probe _probe;
+        private long _count;
+
+        public ActivationCounterBehavior(Probe probe, ScopedResource _)
+        {
+            _probe = probe;
+            _probe.Constructions++;
+        }
+
+        public Task<long> IncrementAsync() => Task.FromResult(++_count);
+
+        public Task OnActivateAsync(CancellationToken ct) => Task.CompletedTask;
+
+        public Task OnDeactivateAsync(DeactivationReason reason, CancellationToken ct)
+        {
+            _probe.DeactivateObservedCount = _count; // must see the cached instance's accumulated state
+            return Task.CompletedTask;
+        }
+    }
+
+    [Reentrant]
+    private sealed class ReentrantActivationBehavior : IActivationBehavior, IReentrantActGrain
+    {
+        public Task NoopAsync() => Task.CompletedTask;
+    }
+
+    // Singleton observation sink.
+    private sealed class Probe
+    {
+        public int Constructions;
+        public int ScopeDisposals;
+        public long DeactivateObservedCount;
+    }
+
+    // Scoped resource resolved into the activation scope; its disposal proves the scope was disposed.
+    private sealed class ScopedResource(Probe probe) : IDisposable
+    {
+        public void Dispose() => probe.ScopeDisposals++;
+    }
+
+    private sealed class Fixture : IAsyncDisposable
+    {
+        private readonly ServiceProvider _sp;
+
+        public Fixture()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.Configure<SiloRuntimeOptions>(o =>
+            {
+                o.ClusterId = "test";
+                o.ServiceId = "activation-scope";
+                o.SiloName = "silo0";
+            });
+
+            services.AddSingleton<GrainTypeRegistry>();
+            services.AddSingleton<IGrainTypeRegistry>(sp => sp.GetRequiredService<GrainTypeRegistry>());
+            services.AddSingleton<InMemoryGrainDirectory>();
+            services.AddSingleton<IGrainDirectory>(sp => sp.GetRequiredService<InMemoryGrainDirectory>());
+            services.AddSingleton<GrainActivationTable>();
+            services.AddSingleton<GrainBehaviorFactoryRegistry>();
+
+            services.AddScoped<ActivationShellAccessor>();
+            services.AddScoped<IActivationShellAccessor>(sp => sp.GetRequiredService<ActivationShellAccessor>());
+            services.AddScoped<CallContext>();
+            services.AddScoped<ICallContext>(sp => sp.GetRequiredService<CallContext>());
+            services.AddScoped<ICallContextSetter>(sp => sp.GetRequiredService<CallContext>());
+            services.AddScoped<IBehaviorResolver, BehaviorResolver>();
+            services.AddSingleton<IUserServiceProviderRegistry, UserServiceProviderRegistry>();
+            services.AddSingleton<QuarkOnlyServiceProviderHolder>();
+
+            Probe = new Probe();
+            services.AddSingleton(Probe);
+            services.AddScoped<ScopedResource>();
+
+            _sp = services.BuildServiceProvider();
+
+            GrainTypeRegistry typeRegistry = _sp.GetRequiredService<GrainTypeRegistry>();
+            typeRegistry.Register(new GrainType("ActCounter"), typeof(ActivationCounterBehavior));
+            typeRegistry.Register(new GrainType("ReentrantAct"), typeof(ReentrantActivationBehavior));
+
+            ActivationTable = _sp.GetRequiredService<GrainActivationTable>();
+            Invoker = new LocalGrainCallInvoker(
+                ActivationTable,
+                typeRegistry,
+                _sp.GetRequiredService<IGrainDirectory>(),
+                _sp,
+                _sp.GetRequiredService<IOptions<SiloRuntimeOptions>>(),
+                NullLogger<LocalGrainCallInvoker>.Instance,
+                NullLogger<GrainActivation>.Instance);
+        }
+
+        public Probe Probe { get; }
+        public GrainActivationTable ActivationTable { get; }
+        public IGrainCallInvoker Invoker { get; }
+
+        public async ValueTask DisposeAsync()
+        {
+            await ActivationTable.DisposeAsync();
+            await _sp.DisposeAsync();
+        }
+    }
+}

--- a/tests/Quark.Tests.Unit/SchedulingSemantics/ArenaSchedulerAsyncResumeTests.cs
+++ b/tests/Quark.Tests.Unit/SchedulingSemantics/ArenaSchedulerAsyncResumeTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Quark.Core.Abstractions.Identity;
+using Quark.Runtime;
+using Xunit;
+
+namespace Quark.Tests.Unit.SchedulingSemantics;
+
+/// <summary>
+///     Validates the <see cref="ArenaScheduler"/>'s async-resume (spill-to-ThreadPool-on-await) behavior:
+///     a worker never blocks <em>inside</em> a turn that awaits, so a non-reentrant call chain deeper
+///     than the worker count still makes progress instead of starving the pool. This is exactly the
+///     bounded-worker reentrancy-deadlock shape (issue #167): under a blocking drain, worker 0 draining
+///     A0 would block awaiting A1, worker 1 would block awaiting A2, and with only N workers a chain of
+///     depth &gt; N deadlocks — every worker parked inside a turn, no worker left to run the next link.
+///     With async resume the awaiting drain suspends and frees its worker, which then runs the next
+///     link, so the chain completes regardless of depth (it completes even with a single worker).
+/// </summary>
+public sealed class ArenaSchedulerAsyncResumeTests
+{
+    [Theory]
+    [InlineData(1)]  // single worker: blocking would deadlock at the very first nested await
+    [InlineData(2)]  // depth (8) far exceeds worker count: blocking would deadlock at depth 2
+    public async Task NonReentrantChainDeeperThanWorkers_CompletesWithoutDeadlock(int workerCount)
+    {
+        const int depth = 8;
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var options = new SiloRuntimeOptions
+        {
+            ClusterId = "test",
+            ServiceId = "arena-scheduler-async-resume",
+            SiloName = "silo0",
+            SchedulerMaxConcurrentActivations = workerCount,
+            SchedulerKind = SchedulerKind.ArenaV2,
+        };
+
+        await using var scheduler = new ArenaScheduler(options);
+        await using ServiceProvider root = services.BuildServiceProvider();
+
+        var chain = new GrainActivation[depth];
+        for (int i = 0; i < depth; i++)
+        {
+            chain[i] = new GrainActivation(
+                new GrainId(new GrainType("ChainGrain"), $"link-{i}"),
+                new GrainType("ChainGrain"),
+                isReentrant: false, // non-reentrant: nested calls MUST go through the scheduler, not inline
+                root,
+                NullLogger<GrainActivation>.Instance,
+                scheduler);
+        }
+
+        var executed = new bool[depth];
+        var order = new ConcurrentQueue<int>();
+
+        // Each link records itself, then awaits a call into the next link — a genuine cross-activation
+        // await from inside a worker drain. The leaf just returns.
+        Func<ValueTask> MakeWork(int level) => async () =>
+        {
+            executed[level] = true;
+            order.Enqueue(level);
+            if (level + 1 < depth)
+                await chain[level + 1].PostAsync(MakeWork(level + 1));
+        };
+
+        // If async resume is broken (worker blocks inside the awaiting turn), this chain deadlocks and
+        // the wait times out. A comfortable timeout keeps the failure a clean assertion, not a hang.
+        await chain[0].PostAsync(MakeWork(0)).AsTask().WaitAsync(TimeSpan.FromSeconds(15));
+
+        for (int i = 0; i < depth; i++)
+            Assert.True(executed[i], $"link {i} never executed (chain stalled at depth {i})");
+
+        Assert.Equal(Enumerable.Range(0, depth), order.ToArray());
+
+        foreach (GrainActivation link in chain)
+            await link.DisposeAsync();
+    }
+}

--- a/tests/Quark.Tests.Unit/SchedulingSemantics/ArenaSchedulerConcurrencyStressTests.cs
+++ b/tests/Quark.Tests.Unit/SchedulingSemantics/ArenaSchedulerConcurrencyStressTests.cs
@@ -1,0 +1,214 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Quark.Core.Abstractions.Identity;
+using Quark.Runtime;
+using Xunit;
+
+namespace Quark.Tests.Unit.SchedulingSemantics;
+
+/// <summary>
+///     Invariant stress tests for the next-generation <see cref="ArenaScheduler"/> (Phase 1) — the
+///     direct counterpart of <see cref="ActivationSchedulerConcurrencyStressTests"/>, run against the
+///     dedicated-worker-thread / work-stealing-deque scheduler instead of the sharded-ready-queue one.
+///     These pin the core P1 invariants from
+///     docs/superpowers/specs/2026-07-12-next-gen-scheduler-design.md:
+///     <list type="bullet">
+///         <item>I1 (single turn): a non-reentrant activation never has two turns executing at once,
+///         even while its mailbox is fed by many concurrent producers and drained by a stealing pool.</item>
+///         <item>I4 (no lost wake): every posted work item is executed exactly once — nothing is
+///         stranded by a missed empty→non-empty wake, including the single-worker park/unpark path.</item>
+///     </list>
+/// </summary>
+public sealed class ArenaSchedulerConcurrencyStressTests
+{
+    [Fact]
+    public async Task ManyConcurrentProducers_AcrossManyActivations_NoWorkIsLost()
+    {
+        const int workerCount = 2; // deliberately small -- forces real cross-worker stealing
+        const int activationCount = 64;
+        const int postsPerActivation = 25;
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var options = new SiloRuntimeOptions
+        {
+            ClusterId = "test",
+            ServiceId = "arena-scheduler-stress",
+            SiloName = "silo0",
+            SchedulerMaxConcurrentActivations = workerCount,
+            SchedulerKind = SchedulerKind.ArenaV2,
+        };
+
+        await using var scheduler = new ArenaScheduler(options);
+        await using ServiceProvider root = services.BuildServiceProvider();
+
+        var activations = new GrainActivation[activationCount];
+        for (int i = 0; i < activationCount; i++)
+        {
+            activations[i] = new GrainActivation(
+                new GrainId(new GrainType("StressGrain"), $"stress-{i}"),
+                new GrainType("StressGrain"),
+                isReentrant: false,
+                root,
+                NullLogger<GrainActivation>.Instance,
+                scheduler);
+        }
+
+        var completedCounts = new int[activationCount];
+        var currentlyExecuting = new int[activationCount];
+        var overlapDetected = new ConcurrentBag<int>();
+
+        var postTasks = new List<Task>(activationCount * postsPerActivation);
+        for (int a = 0; a < activationCount; a++)
+        {
+            int activationIndex = a;
+            for (int p = 0; p < postsPerActivation; p++)
+            {
+                postTasks.Add(Task.Run(() => activations[activationIndex].PostAsync(() =>
+                {
+                    // I1: two turns of the same activation must never overlap.
+                    if (Interlocked.CompareExchange(ref currentlyExecuting[activationIndex], 1, 0) != 0)
+                        overlapDetected.Add(activationIndex);
+
+                    Interlocked.Exchange(ref currentlyExecuting[activationIndex], 0);
+                    Interlocked.Increment(ref completedCounts[activationIndex]);
+
+                    return ValueTask.CompletedTask;
+                }).AsTask()));
+            }
+        }
+
+        await Task.WhenAll(postTasks).WaitAsync(TimeSpan.FromSeconds(30));
+
+        Assert.Empty(overlapDetected);
+        for (int i = 0; i < activationCount; i++)
+        {
+            Assert.True(completedCounts[i] == postsPerActivation,
+                $"Activation {i} completed {completedCounts[i]}/{postsPerActivation} posts -- work was lost.");
+        }
+
+        foreach (GrainActivation activation in activations)
+            await activation.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task TwoConcurrentProducers_SingleWorkerNoFollowUpTraffic_NoWorkIsLost()
+    {
+        // The lost-wakeup-prone shape: two producers enqueue into an all-idle scheduler with no later
+        // traffic to rescue a missed wake. workerCount=1 removes every escape hatch (one worker, one
+        // idle-stack slot, no unrelated wake), so the push-then-recheck double-check is the only thing
+        // standing between correctness and a stranded item.
+        const int iterations = 300;
+
+        for (int iteration = 0; iteration < iterations; iteration++)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            var options = new SiloRuntimeOptions
+            {
+                ClusterId = "test",
+                ServiceId = "arena-scheduler-single-worker",
+                SiloName = "silo0",
+                SchedulerMaxConcurrentActivations = 1,
+                SchedulerKind = SchedulerKind.ArenaV2,
+            };
+
+            await using var scheduler = new ArenaScheduler(options);
+            await using ServiceProvider root = services.BuildServiceProvider();
+
+            var a1 = new GrainActivation(
+                new GrainId(new GrainType("StressGrain"), $"single-worker-a-{iteration}"),
+                new GrainType("StressGrain"),
+                isReentrant: false,
+                root,
+                NullLogger<GrainActivation>.Instance,
+                scheduler);
+            var a2 = new GrainActivation(
+                new GrainId(new GrainType("StressGrain"), $"single-worker-b-{iteration}"),
+                new GrainType("StressGrain"),
+                isReentrant: false,
+                root,
+                NullLogger<GrainActivation>.Instance,
+                scheduler);
+
+            int completed1 = 0;
+            int completed2 = 0;
+
+            Task t1 = Task.Run(() => a1.PostAsync(() =>
+            {
+                Interlocked.Increment(ref completed1);
+                return ValueTask.CompletedTask;
+            }).AsTask());
+            Task t2 = Task.Run(() => a2.PostAsync(() =>
+            {
+                Interlocked.Increment(ref completed2);
+                return ValueTask.CompletedTask;
+            }).AsTask());
+
+            await Task.WhenAll(t1, t2).WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.True(completed1 == 1 && completed2 == 1,
+                $"Iteration {iteration}: work was stranded (completed1={completed1}, completed2={completed2}) -- " +
+                "no follow-up traffic exists to rescue a missed wake.");
+
+            await a1.DisposeAsync();
+            await a2.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task SingleWorker_RepeatedIdleParkCycles_NeverStrandsWork()
+    {
+        // Exercises the idle-stack push -> double-check -> park -> wake path in isolation. workerCount=1
+        // means every idle transition drives the full sequence, and PostAsync awaits each item's own
+        // completion, so the single worker has completed at least one park-or-find-more cycle between
+        // each post with no wall-clock delay needed to force the ordering.
+        const int iterations = 300;
+
+        for (int iteration = 0; iteration < iterations; iteration++)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            var options = new SiloRuntimeOptions
+            {
+                ClusterId = "test",
+                ServiceId = "arena-scheduler-wake-signal",
+                SiloName = "silo0",
+                SchedulerMaxConcurrentActivations = 1,
+                SchedulerKind = SchedulerKind.ArenaV2,
+            };
+
+            await using var scheduler = new ArenaScheduler(options);
+            await using ServiceProvider root = services.BuildServiceProvider();
+
+            var activation = new GrainActivation(
+                new GrainId(new GrainType("StressGrain"), $"idle-park-{iteration}"),
+                new GrainType("StressGrain"),
+                isReentrant: false,
+                root,
+                NullLogger<GrainActivation>.Instance,
+                scheduler);
+
+            int completed = 0;
+
+            for (int post = 0; post < 3; post++)
+            {
+                await activation.PostAsync(() =>
+                {
+                    Interlocked.Increment(ref completed);
+                    return ValueTask.CompletedTask;
+                }).AsTask().WaitAsync(TimeSpan.FromSeconds(2));
+            }
+
+            Assert.True(completed == 3,
+                $"Iteration {iteration}: expected 3 completions, got {completed} -- work was stranded " +
+                "in a single-worker idle-park cycle.");
+
+            await activation.DisposeAsync();
+        }
+    }
+}

--- a/tests/Quark.Tests.Unit/SchedulingSemantics/ArenaSchedulerInFlightBoundTests.cs
+++ b/tests/Quark.Tests.Unit/SchedulingSemantics/ArenaSchedulerInFlightBoundTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Quark.Core.Abstractions.Identity;
+using Quark.Runtime;
+using Xunit;
+
+namespace Quark.Tests.Unit.SchedulingSemantics;
+
+/// <summary>
+///     Validates the <see cref="ArenaScheduler"/>'s per-worker in-flight backpressure
+///     (<see cref="SiloRuntimeOptions.SchedulerMaxInFlightDrainsPerWorker"/>): under a flood of turns
+///     that all suspend on an await, a worker holds at most <c>maxInFlight</c> suspended drains before
+///     it stops taking on more, so silo-wide concurrent suspensions never exceed
+///     <c>workers × maxInFlight</c> — yet every turn still completes once unblocked (the cap applies
+///     backpressure, it does not lose work).
+/// </summary>
+public sealed class ArenaSchedulerInFlightBoundTests
+{
+    [Fact]
+    public async Task SuspendingDrains_AreBoundedPerWorker_AndAllStillComplete()
+    {
+        const int workerCount = 2;
+        const int maxInFlight = 4;
+        const int activationCount = 40; // far more than the workers × cap = 8 the scheduler will suspend at once
+        int cap = workerCount * maxInFlight;
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var options = new SiloRuntimeOptions
+        {
+            ClusterId = "test",
+            ServiceId = "arena-scheduler-inflight-bound",
+            SiloName = "silo0",
+            SchedulerMaxConcurrentActivations = workerCount,
+            SchedulerMaxInFlightDrainsPerWorker = maxInFlight,
+            SchedulerKind = SchedulerKind.ArenaV2,
+        };
+
+        await using var scheduler = new ArenaScheduler(options);
+        scheduler.EnableStatsForTesting();
+        await using ServiceProvider root = services.BuildServiceProvider();
+
+        var activations = new GrainActivation[activationCount];
+        for (int i = 0; i < activationCount; i++)
+        {
+            activations[i] = new GrainActivation(
+                new GrainId(new GrainType("GatedGrain"), $"gated-{i}"),
+                new GrainType("GatedGrain"),
+                isReentrant: false,
+                root,
+                NullLogger<GrainActivation>.Instance,
+                scheduler);
+        }
+
+        // Every turn awaits this gate, so each drain that starts suspends (spills) and counts against its
+        // worker's in-flight budget until the gate is released.
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completed = 0;
+        var completionTasks = new Task[activationCount];
+
+        for (int i = 0; i < activationCount; i++)
+        {
+            completionTasks[i] = activations[i].PostAsync(async () =>
+            {
+                await gate.Task;
+                Interlocked.Increment(ref completed);
+            }).AsTask();
+        }
+
+        // Wait until backpressure is fully engaged: both workers filled to the cap (8 suspended).
+        DateTime deadline = DateTime.UtcNow.AddSeconds(10);
+        while (scheduler.PeakInFlightForTesting() < cap && DateTime.UtcNow < deadline)
+            Thread.Sleep(1);
+
+        Assert.Equal(cap, scheduler.PeakInFlightForTesting());   // reached the cap...
+        Assert.Equal(0, Volatile.Read(ref completed));           // ...and everything is held behind the gate
+
+        // Release the gate — the suspended drains complete, freeing slots, and the queued remainder
+        // drains behind them. All work must complete; the cap only delayed it, never dropped it.
+        gate.SetResult();
+        await Task.WhenAll(completionTasks).WaitAsync(TimeSpan.FromSeconds(30));
+
+        Assert.Equal(activationCount, Volatile.Read(ref completed));
+        Assert.True(scheduler.PeakInFlightForTesting() <= cap,
+            $"peak in-flight {scheduler.PeakInFlightForTesting()} exceeded the bound {cap}");
+
+        foreach (GrainActivation activation in activations)
+            await activation.DisposeAsync();
+    }
+}

--- a/tests/Quark.Tests.Unit/SchedulingSemantics/ArenaSchedulerStealingTests.cs
+++ b/tests/Quark.Tests.Unit/SchedulingSemantics/ArenaSchedulerStealingTests.cs
@@ -1,0 +1,114 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Quark.Core.Abstractions.Identity;
+using Quark.Runtime;
+using Xunit;
+
+namespace Quark.Tests.Unit.SchedulingSemantics;
+
+/// <summary>
+///     Validates that the next-generation <see cref="ArenaScheduler"/> actually exercises its two
+///     defining mechanisms — from-worker local-deque routing and cross-worker work stealing — under the
+///     one workload shape that is safe to do so in the Phase 1/2 blocking-drain model: fire-and-forget
+///     fan-out. A source activation, while running on a worker thread, fires many fire-and-forget posts
+///     to sink activations. Because the source does not block awaiting them, this never risks the
+///     nested-await worker-starvation deadlock that a blocking non-reentrant call chain would.
+///     <para>
+///         The fan-out is raised from a <em>single</em> source drain, so every sink is pushed onto that
+///         one worker's local deque. The remaining workers can only make progress by stealing — so a
+///         correct run both completes all sinks exactly once and records a non-zero steal count spread
+///         across more than one worker thread. This is the coverage AstroSim cannot provide: its grains
+///         are <c>[Reentrant]</c>, so all its calls run inline and never enter the scheduler at all.
+///     </para>
+/// </summary>
+public sealed class ArenaSchedulerStealingTests
+{
+    [Fact]
+    public async Task FromWorkerFanOut_RoutesToLocalDeque_AndIsStolenAcrossWorkers()
+    {
+        const int workerCount = 4;
+        const int sinkCount = 2000;
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var options = new SiloRuntimeOptions
+        {
+            ClusterId = "test",
+            ServiceId = "arena-scheduler-stealing",
+            SiloName = "silo0",
+            SchedulerMaxConcurrentActivations = workerCount,
+            SchedulerKind = SchedulerKind.ArenaV2,
+        };
+
+        await using var scheduler = new ArenaScheduler(options);
+        scheduler.EnableStatsForTesting();
+        await using ServiceProvider root = services.BuildServiceProvider();
+
+        GrainActivation Make(string key) => new(
+            new GrainId(new GrainType("StealGrain"), key),
+            new GrainType("StealGrain"),
+            isReentrant: false,
+            root,
+            NullLogger<GrainActivation>.Instance,
+            scheduler);
+
+        var source = Make("source");
+        var sinks = new GrainActivation[sinkCount];
+        for (int i = 0; i < sinkCount; i++)
+            sinks[i] = Make($"sink-{i}");
+
+        var completed = 0;
+        var doubleRun = new ConcurrentBag<int>();
+        var executed = new int[sinkCount];
+        var sinkThreads = new ConcurrentDictionary<int, byte>();
+
+        // The source's single turn runs on a worker thread and fires one fire-and-forget post per sink.
+        // Each of those PostAsync calls schedules its sink from *inside* a worker drain, so it routes to
+        // that worker's local deque — the from-worker path.
+        await source.PostAsync(() =>
+        {
+            for (int i = 0; i < sinkCount; i++)
+            {
+                int index = i;
+                _ = sinks[index].PostAsync(() =>
+                {
+                    if (Interlocked.Exchange(ref executed[index], 1) != 0)
+                        doubleRun.Add(index);
+
+                    sinkThreads.TryAdd(Environment.CurrentManagedThreadId, 0);
+
+                    // A little work so a single worker cannot drain all 2000 sinks before its idle
+                    // siblings steal any — makes the cross-worker spread deterministic, not a race.
+                    Thread.SpinWait(200);
+
+                    Interlocked.Increment(ref completed);
+                    return ValueTask.CompletedTask;
+                });
+            }
+
+            return ValueTask.CompletedTask;
+        }).AsTask().WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Wait for the fanned-out sinks to drain.
+        var spin = new SpinWait();
+        DateTime deadline = DateTime.UtcNow.AddSeconds(30);
+        while (Volatile.Read(ref completed) < sinkCount && DateTime.UtcNow < deadline)
+            spin.SpinOnce();
+
+        (long external, long local, _, long steals) = scheduler.StatsSnapshot();
+
+        Assert.Equal(sinkCount, Volatile.Read(ref completed));       // no work lost
+        Assert.Empty(doubleRun);                                     // I1: each sink ran exactly once
+        Assert.Equal(sinkCount, local);                              // every sink post took the from-worker route
+        Assert.Equal(1, external);                                   // only the source came from outside a worker
+        Assert.True(steals > 0, $"expected cross-worker steals, got {steals}");
+        Assert.True(sinkThreads.Count > 1,
+            $"expected sinks to run across multiple worker threads, saw {sinkThreads.Count}");
+
+        await source.DisposeAsync();
+        foreach (GrainActivation sink in sinks)
+            await sink.DisposeAsync();
+    }
+}

--- a/tests/Quark.Tests.Unit/SchedulingSemantics/MessagePriorityLaneTests.cs
+++ b/tests/Quark.Tests.Unit/SchedulingSemantics/MessagePriorityLaneTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Quark.Core.Abstractions.Identity;
+using Quark.Core.Abstractions.Scheduling;
+using Quark.Runtime;
+using Xunit;
+
+namespace Quark.Tests.Unit.SchedulingSemantics;
+
+/// <summary>
+///     Validates the per-actor message-priority lanes added to <see cref="GrainActivation"/>'s mailbox:
+///     the drain reads the highest-priority non-empty lane first, so a higher-priority message jumps
+///     ahead of lower-priority messages already queued for the same grain, while messages within one
+///     lane preserve arrival order (FIFO). The lanes live in the shared mailbox, so this holds for any
+///     scheduler; the test drives it through the arena scheduler.
+/// </summary>
+public sealed class MessagePriorityLaneTests
+{
+    [Fact]
+    public async Task HigherPriorityMessages_DrainAhead_LowerOnesQueuedFirst_FifoWithinLane()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var options = new SiloRuntimeOptions
+        {
+            ClusterId = "test",
+            ServiceId = "message-priority-lanes",
+            SiloName = "silo0",
+            SchedulerMaxConcurrentActivations = 2,
+            SchedulerKind = SchedulerKind.ArenaV2,
+        };
+
+        await using var scheduler = new ArenaScheduler(options);
+        await using ServiceProvider root = services.BuildServiceProvider();
+
+        var activation = new GrainActivation(
+            new GrainId(new GrainType("PriorityGrain"), "p"),
+            new GrainType("PriorityGrain"),
+            isReentrant: false,
+            root,
+            NullLogger<GrainActivation>.Instance,
+            scheduler);
+
+        var order = new List<string>();
+        void Record(string label)
+        {
+            lock (order) order.Add(label);
+        }
+
+        using var started = new ManualResetEventSlim(false);
+        using var gate = new ManualResetEventSlim(false);
+
+        // A blocker occupies the single drain synchronously, so everything posted below lands in the
+        // mailbox lanes (they enqueue synchronously — unbounded lanes) before the drain reads any of it.
+        Task blockerTask = activation.PostAsync(() =>
+        {
+            Record("blocker");
+            started.Set();
+            gate.Wait(TimeSpan.FromSeconds(10));
+            return default;
+        }).AsTask();
+
+        Assert.True(started.Wait(TimeSpan.FromSeconds(10)), "blocker never started draining");
+
+        // Post out of priority order, and two at Normal to check FIFO within a lane. Each PostAsync
+        // enqueues synchronously to its lane before suspending on completion, so all five are queued
+        // behind the blocker before the gate is released.
+        Func<ValueTask> Make(string label) => () => { Record(label); return default; };
+
+        Task low = activation.PostAsync(Make("low"), MessagePriority.Low).AsTask();
+        Task urgent = activation.PostAsync(Make("urgent"), MessagePriority.Urgent).AsTask();
+        Task normal1 = activation.PostAsync(Make("normal-1"), MessagePriority.Normal).AsTask();
+        Task high = activation.PostAsync(Make("high"), MessagePriority.High).AsTask();
+        Task normal2 = activation.PostAsync(Make("normal-2"), MessagePriority.Normal).AsTask();
+
+        gate.Set();
+        await Task.WhenAll(blockerTask, low, urgent, normal1, high, normal2).WaitAsync(TimeSpan.FromSeconds(15));
+
+        List<string> drained;
+        lock (order) drained = order.ToList();
+
+        // blocker ran first (it was already draining), then strict priority order across lanes with
+        // FIFO within the Normal lane (normal-1 posted before normal-2).
+        Assert.Equal(
+            new[] { "blocker", "urgent", "high", "normal-1", "normal-2", "low" },
+            drained);
+
+        await activation.DisposeAsync();
+    }
+}


### PR DESCRIPTION
Drives the activation-scoped grain-call dispatch path toward true-zero steady-state allocation, ranked by measured bytes. Three orthogonal features that ship together; the branch tip builds clean (0 warnings) and is green across scheduling 45/45, Fault 9/9, Integration 38/38, unit 549–550/550 (the 1–2 residual failures are documented wall-clock timing flakes that shift across runs and pass in isolation).

## Commits

### 1. `IActivationBehavior` dual behavior model (Part A)
An opt-in **per-activation** behavior lifetime alongside the existing per-call `IGrainBehavior`, killing the ~792 B/call DI-scope + resolution bucket for grains that opt in.
- One activation-lifetime `IServiceScope` + one cached behavior instance in `GrainActivation` (constructed once, reused per call, disposed on deactivation).
- `LocalGrainCallInvoker` fast path: no scope, no construct, no locked `ResolveService`. Reentrant + `IActivationBehavior` throws `NotSupportedException`.
- `BehaviorStateAnalyzer`: suppress QRK0020/QRK0021 for `IActivationBehavior` (per-activation fields are legitimate state); QRK0022 still fires; new **QRK0023** (Warning) flags `[Reentrant]` + `IActivationBehavior`.
- `PostCoreAsync` variants use `PoolingAsyncValueTaskMethodBuilder` so dispatch async boxes are pooled.
- **Measured (DispatchPipelineBenchmarks): 2039 → 1253 B/call** for opted-in grains (−786 B); mean latency 14.2 → 6.8 µs.

### 2. Opt-in `ArenaScheduler` (next-gen scheduler, ArenaV2)
A fresh `IActivationScheduler` on dedicated worker threads, per-worker work-stealing deques, and a sharded injection queue — the P1 skeleton of the next-gen scheduler design. Selected only via `SiloRuntimeOptions.SchedulerKind == ArenaV2`; **the legacy scheduler stays the default** until the arena scheduler clears the full benchmark suite.
- Spill-to-ThreadPool on await removes both blocking-drain latency and the bounded-worker reentrancy deadlock.
- Per-worker in-flight backpressure (Dekker-fenced); same lost-wakeup-free park ordering as the legacy scheduler.
- Coverage: async-resume, concurrency stress, in-flight bound, stealing, message-priority-lane tests. Perf runners gain `--v2`.

### 3. Low-alloc dispatch — allocation-free park primitive + shutdown fix
- **`WorkerParkSignal`** replaces the per-worker `SemaphoreSlim(0, int.MaxValue)`, whose cancelable `WaitAsync(ct)` slow path allocated ~200 B/park in the park regime. A single-consumer/multi-producer async auto-reset event backed by a reusable `ManualResetValueTaskSourceCore<bool>` — a park now allocates **nothing**. Token-free; `DisposeAsync` `Set()`s every worker on shutdown. A boolean auto-reset event is sound because the wake is edge-triggered (one wake re-sweeps all shards). Verified against **20M** multi-producer/consumer cycles of the exact wake protocol, zero lost wakes.
- Folded-in earlier reductions from the same arc: spin-before-park, lock-free `long[]` bitmask idle registry (replacing `ConcurrentStack<int>`), `StatelessWorkerRouter` delegate caching, state-passing `GrainActivationTable.GetOrCreateAsync<TState>` overload.
- **Shutdown fix (pre-existing latent bug the primitive uncovered):** since the `Channel → ConcurrentQueue` ready-queue rewrite, `ScheduleAsync` stopped rejecting work after shutdown, so an activation deactivating after the scheduler is disposed (the DI dispose order) posted its `OnDeactivate` turn onto dead workers and hung forever. The old `Channel` threw `ChannelClosedException` here, driving `GrainActivation`'s inline-drain fallback; the `SemaphoreSlim` primitive was masking the gap by accidentally throwing `ObjectDisposedException` from a disposed semaphore. `ScheduleAsync` now throws `ObjectDisposedException` when `_cts.IsCancellationRequested` (one hot-path volatile read), restoring the reject-on-shutdown contract explicitly. Locked in by `ActivationSchedulerShutdownRejectsScheduleTests` (both tests fail — one by hanging — with the guard removed).
- **Measured (AllocByTypeProfiler, park regime): ~200 → 1.3–1.9 B/call**, residual is just the pooled `MailboxWorkItem<T>`.

## Notes for reviewers
- Commits are split by feature. Two shared runtime files (`GrainActivation.cs`, `LocalGrainCallInvoker.cs`) carry both Part A and Part B edits and land in commit 1 as the runtime enablement for `IActivationBehavior`; their pooling-builder micro-opts are described in commit 3's body and the design spec.
- Design specs under `docs/superpowers/specs/` (`2026-07-12-next-gen-scheduler-design.md`, `2026-07-13-low-alloc-dispatch-design.md`, `2026-07-13-scheduler-v2-pingpong-cost-profile.md`).
- Follow-up tracked in the spec: `ArenaScheduler.ScheduleAsync` has the same latent reject-on-shutdown gap (opt-in, currently accidentally-masked); needs `ValueTask.FromException` since its `ScheduleAsync` is synchronous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)